### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,42 @@
+pipeline {
+    agent {
+        label "lab"
+    }
+
+    triggers {
+        pollSCM('0 * * * *')
+    }
+
+    stages {
+        stage('Checkout GH Pages') {
+            steps {
+                dir("gh-pages") {
+                    git branch: "gh-pages", changelog: false, poll: false, url: "git@github.com:hazelcast/charts.git"
+                }
+            }
+        }
+
+        stage('Package Helm') {
+            steps {
+                dir("gh-pages") {
+                    script {
+                        sh 'for CHART in ../stable/*; do helm package --save=false ${CHART}; done'
+                        sh "helm repo index --url=https://hazelcast.github.com/charts/ ."
+                    }
+                }
+            }
+        }
+        stage('Push changes') {
+            steps {
+                dir("gh-pages") {
+                    script {
+                        sh 'git add .'
+                        sh 'git commit -m "New Chart version"'
+                        sh 'git push origin gh-pages'
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,6 @@ pipeline {
         label "lab"
     }
 
-    triggers {
-        pollSCM('0 * * * *')
-    }
-
     stages {
         stage('Checkout GH Pages') {
             steps {


### PR DESCRIPTION
Create Continuous Build for the Hazelcast Charts repository. It automatically publish all charts that are in `master` to the chart repository (`gh-pages` branch)

Jenkins Build: https://hazelcast-l337.ci.cloudbees.com/job/Charts-master/

Note that if we wanted to be fully CD with the Hazelcast Charts (like it is in the official Helm Chart repo), then we would also need to add e2e tests and the `PR-builder` Jenkins build. However, since it implies maintaining (and paying for) the Kubernetes environment, I'm not sure we want it atm.