### PR TITLE
Rolling upgrade

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 name: hazelcast-enterprise
-version: 1.0.1
-appVersion: "3.10.3"
+version: 1.0.2
+appVersion: "3.11"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:
 - hazelcast

--- a/stable/hazelcast-enterprise/templates/mancenter-service.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mancenter.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,3 +22,4 @@ spec:
     port: {{ .Values.mancenter.service.port }}
     targetPort: mancenter
     name: mancenterport
+{{- end }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -31,6 +31,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.gracefulShutdown.enabled }}
+      terminationGracePeriodSeconds: {{ .Values.gracefulShutdown.maxWaitSeconds }}
+      {{- end }}
       containers:
       - name: {{ template "hazelcast.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -76,7 +79,7 @@ spec:
           value: {{ .Values.hazelcast.licenseKey }}
         {{- end }}
         - name: JAVA_OPTS
-          value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.mancenter.url=http://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ .Values.hazelcast.javaOpts }}"
+          value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.mancenter.url=http://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }}{{ .Values.hazelcast.javaOpts }}"
       serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       volumes:
       - name: hazelcast-storage

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -52,6 +52,7 @@ hazelcast:
                 <properties>
                   <property name="service-name">${serviceName}</property>
                   <property name="namespace">${namespace}</property>
+                  <property name="resolve-not-ready-addresses">true</property>
                 </properties>
               </discovery-strategy>
             </discovery-strategies>
@@ -66,6 +67,10 @@ hazelcast:
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+gracefulShutdown:
+  enabled: true
+  maxWaitSeconds: 600
+
 # Hazelcast Liveness probe
 livenessProbe:
   # enabled is a flag to used to enable liveness probe
@@ -75,11 +80,11 @@ livenessProbe:
   # periodSeconds decides how often to perform the probe
   periodSeconds: 10
   # timeoutSeconds decides when the probe times out
-  timeoutSeconds: 5
+  timeoutSeconds: 10
   # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
   successThreshold: 1
   # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
-  failureThreshold: 3
+  failureThreshold: 10
 
 # Hazelcast Readiness probe
 readinessProbe:
@@ -90,11 +95,11 @@ readinessProbe:
   # periodSeconds decides how often to perform the probe
   periodSeconds: 10
   # timeoutSeconds decides when the probe times out
-  timeoutSeconds: 1
+  timeoutSeconds: 10
   # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
   successThreshold: 1
   # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
-  failureThreshold: 3
+  failureThreshold: 10
 
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -5,7 +5,7 @@ image:
   # repository is the Hazelcast image name
   repository: "hazelcast/hazelcast-enterprise"
   # tag is the Hazelcast image tag
-  tag: "3.10.3"
+  tag: "3.11"
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 name: hazelcast
-version: 1.0.1
-appVersion: "3.10.3"
+version: 1.0.2
+appVersion: "3.11"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:
 - hazelcast

--- a/stable/hazelcast/templates/mancenter-service.yaml
+++ b/stable/hazelcast/templates/mancenter-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mancenter.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,3 +22,4 @@ spec:
     port: {{ .Values.mancenter.service.port }}
     targetPort: mancenter
     name: mancenterport
+{{- end }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -31,6 +31,9 @@ spec:
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.gracefulShutdown.enabled }}
+      terminationGracePeriodSeconds: {{ .Values.gracefulShutdown.maxWaitSeconds }}
+      {{- end }}
       containers:
       - name: {{ template "hazelcast.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -67,7 +70,7 @@ spec:
           mountPath: /data/hazelcast
         env:
         - name: JAVA_OPTS
-          value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.mancenter.url=http://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ .Values.hazelcast.javaOpts }}"
+          value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.mancenter.url=http://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }}{{ .Values.hazelcast.javaOpts }}"
       serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       volumes:
       - name: hazelcast-storage

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -48,6 +48,7 @@ hazelcast:
                 <properties>
                   <property name="service-name">${serviceName}</property>
                   <property name="namespace">${namespace}</property>
+                  <property name="resolve-not-ready-addresses">true</property>
                 </properties>
               </discovery-strategy>
             </discovery-strategies>
@@ -62,6 +63,10 @@ hazelcast:
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+gracefulShutdown:
+  enabled: true
+  maxWaitSeconds: 600
+
 # Hazelcast Liveness probe
 livenessProbe:
   # enabled is a flag to used to enable liveness probe
@@ -71,11 +76,11 @@ livenessProbe:
   # periodSeconds decides how often to perform the probe
   periodSeconds: 10
   # timeoutSeconds decides when the probe times out
-  timeoutSeconds: 5
+  timeoutSeconds: 10
   # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
   successThreshold: 1
   # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
-  failureThreshold: 3
+  failureThreshold: 10
 
 # Hazelcast Readiness probe
 readinessProbe:
@@ -86,11 +91,11 @@ readinessProbe:
   # periodSeconds decides how often to perform the probe
   periodSeconds: 10
   # timeoutSeconds decides when the probe times out
-  timeoutSeconds: 1
+  timeoutSeconds: 10
   # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
   successThreshold: 1
   # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
-  failureThreshold: 3
+  failureThreshold: 10
 
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -5,7 +5,7 @@ image:
   # repository is the Hazelcast image name
   repository: "hazelcast/hazelcast"
   # tag is the Hazelcast image tag
-  tag: "3.10.3"
+  tag: "3.11"
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images


### PR DESCRIPTION
Next version of Helm Chart, which includes the following changes:
- Update Hazelcast to 3.11
- Add Graceful Shutdown feature (used in scaling down and rolling upgrade)
- Add check to not create Management Center service is mancenter.enabled==false
- Add `resolve-not-ready-addresses` property to check also not ready Hazelcast PODs
- Increase default parameters for livenessProbe and readinessProbe (helps in stability in case of rolling upgrade and huge amount of data)