### PR TITLE
Apply advice recommended by kubesec.io

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast-enterprise
-version: 1.1.3
+version: 1.1.4
 appVersion: "3.11"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 name: hazelcast-enterprise
 version: 1.1.4
-appVersion: "3.11"
+appVersion: "3.11.2"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:
 - hazelcast

--- a/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
@@ -95,6 +95,7 @@ spec:
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}
           runAsNonRoot: true
           {{- end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
@@ -32,11 +32,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.mancenter.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
       containers:
       - name: {{ template "mancenter.fullname" . }}
         image: "{{ .Values.mancenter.image.repository }}:{{ .Values.mancenter.image.tag }}"
@@ -96,6 +91,21 @@ spec:
         {{- end }}
         - name: JAVA_OPTS
           value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          fsGroup: {{ .Values.securityContext.fsGroup }}
+          {{- if .Values.securityContext.runAsUser }}
+          runAsNonRoot: true
+          {{- end }}
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       volumes:
       - name: mancenter-storage
       {{- if .Values.mancenter.persistence.enabled }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -96,6 +96,7 @@ spec:
           runAsUser: {{ .Values.securityContext.runAsUser }}
           fsGroup: {{ .Values.securityContext.fsGroup }}
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}
           runAsNonRoot: true
           {{- end }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -103,6 +103,7 @@ spec:
             drop:
             - ALL
         {{- end }}
+      serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       volumes:
       - name: hazelcast-storage
         configMap:

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -90,12 +90,19 @@ spec:
         {{- end }}
         - name: JAVA_OPTS
           value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.ssl={{ .Values.hazelcast.ssl }} -Dhazelcast.mancenter.url={{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ .Values.hazelcast.javaOpts }}"
-      serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
+        serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          fsGroup: {{ .Values.securityContext.fsGroup }}
+          readOnlyRootFilesystem: true
+          {{- if .Values.securityContext.runAsUser }}
+          runAsNonRoot: true
+          {{- end }}
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
       volumes:
       - name: hazelcast-storage
         configMap:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -108,6 +108,9 @@ readinessProbe:
 #   requests:
 #     memory: 256Mi
 #     cpu: 100m
+#   limits:
+#     memory: 1024Mi
+#     cpu: 200m
 
 # Hazelcast Service properties
 service:
@@ -138,9 +141,9 @@ securityContext:
   # enabled is a flag to enable Security Context
   enabled: true
   # runAsUser is the user ID used to run the container
-  runAsUser: 1001
+  runAsUser: 100100
   # fsGroup is the group ID associated with the container
-  fsGroup: 1001
+  fsGroup: 100100
 
 # secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
 # secretsMountName:
@@ -193,6 +196,9 @@ mancenter:
   #   requests:
   #     memory: 256Mi
   #     cpu: 100m
+  #   limits:
+  #     memory: 1024Mi
+  #     cpu: 200m
 
   # Management Center persistence properties
   persistence:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -5,7 +5,7 @@ image:
   # repository is the Hazelcast image name
   repository: "hazelcast/hazelcast-enterprise"
   # tag is the Hazelcast image tag
-  tag: "3.11"
+  tag: "3.11.2"
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast
-version: 1.1.2
+version: 1.1.3
 appVersion: "3.11"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 name: hazelcast
 version: 1.1.3
-appVersion: "3.11"
+appVersion: "3.11.2"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:
 - hazelcast

--- a/stable/hazelcast/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast/templates/mancenter-deployment.yaml
@@ -32,11 +32,6 @@ spec:
       nodeSelector:
 {{ toYaml .Values.mancenter.nodeSelector | indent 8 }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
       containers:
       - name: {{ template "mancenter.fullname" . }}
         image: "{{ .Values.mancenter.image.repository }}:{{ .Values.mancenter.image.tag }}"
@@ -83,6 +78,21 @@ spec:
         {{- end }}
         - name: JAVA_OPTS
           value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ .Values.mancenter.javaOpts }}"
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          fsGroup: {{ .Values.securityContext.fsGroup }}
+          {{- if .Values.securityContext.runAsUser }}
+          runAsNonRoot: true
+          {{- end }}
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       volumes:
       - name: mancenter-storage
       {{- if .Values.mancenter.persistence.enabled }}

--- a/stable/hazelcast/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast/templates/mancenter-deployment.yaml
@@ -82,6 +82,7 @@ spec:
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
           fsGroup: {{ .Values.securityContext.fsGroup }}
+          allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}
           runAsNonRoot: true
           {{- end }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -88,6 +88,7 @@ spec:
             drop:
             - ALL
         {{- end }}
+      serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       volumes:
       - name: hazelcast-storage
         configMap:

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -81,6 +81,7 @@ spec:
           runAsUser: {{ .Values.securityContext.runAsUser }}
           fsGroup: {{ .Values.securityContext.fsGroup }}
           readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}
           runAsNonRoot: true
           {{- end }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -75,12 +75,19 @@ spec:
         env:
         - name: JAVA_OPTS
           value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.mancenter.url=http://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }}{{ .Values.hazelcast.javaOpts }}"
-      serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        runAsUser: {{ .Values.securityContext.runAsUser }}
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
+        serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          runAsUser: {{ .Values.securityContext.runAsUser }}
+          fsGroup: {{ .Values.securityContext.fsGroup }}
+          readOnlyRootFilesystem: true
+          {{- if .Values.securityContext.runAsUser }}
+          runAsNonRoot: true
+          {{- end }}
+          capabilities:
+            drop:
+            - ALL
+        {{- end }}
       volumes:
       - name: hazelcast-storage
         configMap:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -99,6 +99,9 @@ readinessProbe:
 #   requests:
 #     memory: 256Mi
 #     cpu: 100m
+#   limits:
+#     memory: 1024Mi
+#     cpu: 200m
 
 # Hazelcast Service properties
 service:
@@ -129,9 +132,9 @@ securityContext:
   # enabled is a flag to enable Security Context
   enabled: true
   # runAsUser is the user ID used to run the container
-  runAsUser: 1001
+  runAsUser: 100100
   # fsGroup is the group ID associated with the container
-  fsGroup: 1001
+  fsGroup: 100100
 
 # customVolume is the configuration for any volume mounted as '/data/custom/' (e.g. to mount a volume with custom JARs)
 # customVolume:
@@ -179,6 +182,9 @@ mancenter:
   #   requests:
   #     memory: 256Mi
   #     cpu: 100m
+  #   limits:
+  #     memory: 1024Mi
+  #     cpu: 200m
 
   # Management Center persistence properties
   persistence:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -5,7 +5,7 @@ image:
   # repository is the Hazelcast image name
   repository: "hazelcast/hazelcast"
   # tag is the Hazelcast image tag
-  tag: "3.11"
+  tag: "3.11.2"
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images


### PR DESCRIPTION
**Note**: There are no functional changes in this PR.

fix #21 

After this changes the following advice messages are still reported.

### 1. Read Only Root Filesystem
```
containers[] .securityContext .readOnlyRootFilesystem == true
An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost
```
Management Center requires writing to the root filesystem. We could probably change it, but it would require making a change in the Management Center Dockerfile (and maybe Management Center itself). I left it for now.

### 2. Resources

```
containers[] .resources .limits .memory
Enforcing memory limits prevents DOS via resource exhaustion
containers[] .resources .limits .cpu
Enforcing CPU limits prevents DOS via resource exhaustion
containers[] .resources .requests .memory
Enforcing memory requests aids a fair balancing of resources across the cluster
containers[] .resources .requests .cpu
Enforcing CPU requests aids a fair balancing of resources across the cluster
```
This message is contrary to what Helm Chart guide recommends. The official repo even does not accepts Helm Charts with explicitly defined resources.

### 3. Volume Claim Templates Access Mode

```
.spec .volumeClaimTemplates[] .spec .accessModes | index("ReadWriteOnce")
```
This looks like a bug in Kubesec.io, because we don't have any `volumeClaimTemplate` in the Hazelcast StatefulSet definition.