### PR TITLE
fix lint errors

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast-enterprise
-version: 1.3.0
+version: 1.3.1
 appVersion: "3.11.2"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
@@ -19,6 +19,8 @@ spec:
     metadata:
       labels:
         app: {{ template "hazelcast.name" . }}
+        chart: {{ template "hazelcast.chart" . }}
+        heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
         role: mancenter
     spec:
@@ -94,7 +96,6 @@ spec:
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
-          fsGroup: {{ .Values.securityContext.fsGroup }}
           allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}
           runAsNonRoot: true

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -14,10 +14,13 @@ spec:
       app: {{ template "hazelcast.name" . }}
       release: "{{ .Release.Name }}"
       role: hazelcast
+  serviceName: {{ template "hazelcast.fullname" . }}
   template:
     metadata:
       labels:
         app: {{ template "hazelcast.name" . }}
+        chart: {{ template "hazelcast.chart" . }}
+        heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
         role: hazelcast
     spec:
@@ -98,11 +101,9 @@ spec:
         {{- end }}
         - name: JAVA_OPTS
           value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.ssl={{ .Values.hazelcast.ssl }} -Dhazelcast.mancenter.url={{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
-        serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
-          fsGroup: {{ .Values.securityContext.fsGroup }}
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast
-version: 1.3.0
+version: 1.3.1
 appVersion: "3.11.2"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast/templates/mancenter-deployment.yaml
@@ -19,6 +19,8 @@ spec:
     metadata:
       labels:
         app: {{ template "hazelcast.name" . }}
+        chart: {{ template "hazelcast.chart" . }}
+        heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
         role: mancenter
     spec:
@@ -81,7 +83,6 @@ spec:
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
-          fsGroup: {{ .Values.securityContext.fsGroup }}
           allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}
           runAsNonRoot: true

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -14,10 +14,13 @@ spec:
       app: {{ template "hazelcast.name" . }}
       release: "{{ .Release.Name }}"
       role: hazelcast
+  serviceName: {{ template "hazelcast.fullname" . }}
   template:
     metadata:
       labels:
         app: {{ template "hazelcast.name" . }}
+        chart: {{ template "hazelcast.chart" . }}
+        heritage: "{{ .Release.Service }}"
         release: "{{ .Release.Name }}"
         role: hazelcast
     spec:
@@ -83,11 +86,9 @@ spec:
         {{- end }}
         - name: JAVA_OPTS
           value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.xml -DserviceName={{ template "hazelcast.fullname" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.mancenter.url=http://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
-        serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
-          fsGroup: {{ .Values.securityContext.fsGroup }}
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           {{- if .Values.securityContext.runAsUser }}


### PR DESCRIPTION
`[ERROR] templates/mancenter-deployment.yaml: invalid schema: ValidationError(Deployment.spec.template.spec.containers[0].securityContext): unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext`

fsGroup is not a option for the securityContext of the Container, only the Pod

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#securitycontext-v1-core

---

`[ERROR] templates/mancenter-deployment.yaml: missing required metadata labels: missing chart, heritage under spec.template.metadata.labels`

Added the labels

---

`[ERROR] templates/statefulset.yaml: invalid schema: [`

---

`ValidationError(StatefulSet.spec.template.spec.containers[0].securityContext): unknown field "fsGroup" in io.k8s.api.core.v1.SecurityContext,`

fsGroup is not a option for the securityContext of the Container, only the Pod

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#securitycontext-v1-core
 
 ---

`ValidationError(StatefulSet.spec.template.spec.containers[0]): unknown field "serviceAccountName" in io.k8s.api.core.v1.Container,`

serviceAccountName is not an option on Container, only Pod

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#container-v1-core

 ---

`ValidationError(StatefulSet.spec): missing required field "serviceName" in io.k8s.api.apps.v1.StatefulSetSpec]`

Connect the StatefulSet to the Service identity

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.12/#statefulsetspec-v1-apps
https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id