### PR TITLE
Add service account for Management Center

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast-enterprise
-version: 1.3.0
+version: 1.3.1
 appVersion: "3.11.2"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-deployment.yaml
@@ -91,6 +91,7 @@ spec:
         {{- end }}
         - name: JAVA_OPTS
           value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
+        serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -107,6 +108,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
+      serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       volumes:
       - name: mancenter-storage
       {{- if .Values.mancenter.persistence.enabled }}

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast
-version: 1.3.0
+version: 1.3.1
 appVersion: "3.11.2"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.
 keywords:

--- a/stable/hazelcast/templates/mancenter-deployment.yaml
+++ b/stable/hazelcast/templates/mancenter-deployment.yaml
@@ -78,6 +78,7 @@ spec:
         {{- end }}
         - name: JAVA_OPTS
           value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ .Values.mancenter.javaOpts }}"
+        serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsUser: {{ .Values.securityContext.runAsUser }}
@@ -94,6 +95,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
       {{- end }}
+      serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       volumes:
       - name: mancenter-storage
       {{- if .Values.mancenter.persistence.enabled }}


### PR DESCRIPTION
As recommended in the OperatorHub PR: https://github.com/operator-framework/community-operators/pull/190#issuecomment-477613716

Better not to use the default service account.