### PR TITLE
Add hostPort and existingConfigMap

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast-enterprise
-version: 1.6.0
+version: 1.6.1
 appVersion: "3.12.1"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast-enterprise
-version: 1.6.1
+version: 1.7.0
 appVersion: "3.12.1"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -57,8 +57,11 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `hazelcast.ssl`                            | Enable SSL for Hazelcast                                                                                       | `false`                                              |
 | `hazelcast.updateClusterVersionAfterRollingUpgrade` | Enable Hazelcast cluster auto version upgrade after the rolling upgrade procedure                              | `true`                                               |
 | `hazelcast.javaOpts`                       | Additional JAVA_OPTS properties for Hazelcast member                                                           | `nil`                                                |
-| `hazelcast.configurationFiles`             | Hazelcast configuration files                                                                                  | `{DEFAULT_HAZELCAST_XML}`                            |
+| `hazelcast.existingConfigMap`              | ConfigMap which contains Hazelcast configuration file(s) that are used instead hazelcast.yaml embedded into values.yaml | `nil`                                                |
+| `hazelcast.yaml`                           | Hazelcast YAML Configuration (`hazelcast.yaml` embedded into `values.yaml`)                                    | `{DEFAULT_HAZELCAST_YAML}`                           |
+| `hazelcast.configurationFiles`             | Hazelcast configuration files                                                                                  | `nil`                                                |
 | `nodeSelector`                             | Hazelcast Node labels for pod assignment                                                                       | `nil`                                                |
+| `hostPort`                                 | Port under which Hazelcast PODs are exposed on the host machines                                               | `nil`                                                |
 | `gracefulShutdown.enabled`                 | Turn on and off Graceful Shutdown                                                                              | `true`                                               |
 | `gracefulShutdown.maxWaitSeconds`          | Maximum time to wait for the Hazelcast POD to shut down                                                        | `600`                                                |
 | `livenessProbe.enabled`                    | Turn on and off liveness probe                                                                                 | `true`                                               |
@@ -149,35 +152,22 @@ $ helm install --name my-release -f values.yaml hazelcast/hazelcast-enterprise
 
 ## Custom Hazelcast configuration
 
-Custom Hazelcast configuration can be specified inside `values.yaml`, as the `hazelcast.configurationFiles.hazelcast.xml` property.
+Custom Hazelcast configuration can be specified inside `values.yaml`, as the `hazelcast.yaml` property.
 
 ```yaml
 hazelcast:
-  configurationFiles:
-    hazelcast.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-                     xmlns="http://www.hazelcast.com/schema/config"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <network>
-          <join>
-            <multicast enabled="false"/>
-            <tcp-ip enabled="false" />
-            <discovery-strategies>
-              <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-              </discovery-strategy>
-            </discovery-strategies>
-          </join>
-        </network>
-
-        <management-center enabled="${hazelcast.mancenter.enabled}">${hazelcast.mancenter.url}</management-center>
-
+   yaml:
+    hazelcast:
+      network:
+        join:
+          multicast:
+            enabled: false
+          kubernetes:
+            enabled: true
+            service-name: ${serviceName}
+            namespace: ${namespace}
+            resolve-not-ready-addresses: true
         <!-- Custom Configuration Placeholder -->
-      </hazelcast>
 ```
 
 ## Configuring SSL

--- a/stable/hazelcast-enterprise/templates/config.yaml
+++ b/stable/hazelcast-enterprise/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.hazelcast.configurationFiles .Values.hazelcast.yaml }}
+{{- if and (or .Values.hazelcast.configurationFiles .Values.hazelcast.yaml) (not .Values.hazelcast.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -53,6 +53,7 @@ spec:
         ports:
         - name: hazelcast
           containerPort: 5701
+          hostPort: {{ .Values.hostPort }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: {{ .Values.metrics.service.port }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -132,7 +132,11 @@ spec:
       volumes:
       - name: hazelcast-storage
         configMap:
+          {{- if .Values.hazelcast.existingConfigMap }}
+          name: {{ .Values.hazelcast.existingConfigMap }}
+          {{- else }}
           name: {{ template "hazelcast.fullname" . }}-configuration
+          {{- end }}
       {{- if .Values.hotRestart.enabled }}
       - name: hot-restart-persistence
         persistentVolumeClaim:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -68,7 +68,7 @@ hazelcast:
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
-# hostPort is a port under which Hazelcast PODs are exposed on the host machine
+# hostPort is a port under which Hazelcast PODs are exposed on the host machines
 # hostPort:
 
 gracefulShutdown:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -66,6 +66,9 @@ hazelcast:
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
 
+# hostPort is a port under which Hazelcast PODs are exposed on the host machine
+# hostPort:
+
 gracefulShutdown:
   enabled: true
   maxWaitSeconds: 600

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -36,6 +36,8 @@ hazelcast:
   updateClusterVersionAfterRollingUpgrade: true
   # javaOpts are additional JAVA_OPTS properties for Hazelcast member
   javaOpts:
+  # existingConfigMap defines a ConfigMap which contains Hazelcast configuration file(s) that are used instead hazelcast.yaml configuration below
+  # existingConfigMap
   # yaml is the Hazelcast YAML configuration file
   yaml:
     hazelcast:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast
-version: 1.5.0
+version: 1.6.0
 appVersion: "3.12.1"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -53,8 +53,11 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `cluster.memberCount`                      | Number of Hazelcast members                                                                                    | 2                                                    |
 | `hazelcast.rest`                           | Enable REST endpoints for Hazelcast member                                                                     | `true`                                               |
 | `hazelcast.javaOpts`                       | Additional JAVA_OPTS properties for Hazelcast member                                                           | `nil`                                                |
-| `hazelcast.configurationFiles`             | Hazelcast configuration files                                                                                  | `{DEFAULT_HAZELCAST_XML}`                            |
+| `hazelcast.existingConfigMap`              | ConfigMap which contains Hazelcast configuration file(s) that are used instead hazelcast.yaml embedded into values.yaml | `nil`                                                |
+| `hazelcast.yaml`                           | Hazelcast YAML Configuration (`hazelcast.yaml` embedded into `values.yaml`)                                    | `{DEFAULT_HAZELCAST_YAML}`                           |
+| `hazelcast.configurationFiles`             | Hazelcast configuration files                                                                                  | `nil`                                                |
 | `nodeSelector`                             | Hazelcast Node labels for pod assignment                                                                       | `nil`                                                |
+| `hostPort`                                 | Port under which Hazelcast PODs are exposed on the host machines                                               | `nil`                                                |
 | `gracefulShutdown.enabled`                 | Turn on and off Graceful Shutdown                                                                              | `true`                                               |
 | `gracefulShutdown.maxWaitSeconds`          | Maximum time to wait for the Hazelcast POD to shut down                                                        | `600`                                                |
 | `livenessProbe.enabled`                    | Turn on and off liveness probe                                                                                 | `true`                                               |
@@ -139,33 +142,20 @@ $ helm install --name my-release -f values.yaml hazelcast/hazelcast
 
 ## Custom Hazelcast configuration
 
-Custom Hazelcast configuration can be specified inside `values.yaml`, as the `hazelcast.configurationFiles.hazelcast.xml` property.
+Custom Hazelcast configuration can be specified inside `values.yaml`, as the `hazelcast.yaml` property.
 
 ```yaml
 hazelcast:
-  configurationFiles:
-    hazelcast.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-                     xmlns="http://www.hazelcast.com/schema/config"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <network>
-          <join>
-            <multicast enabled="false"/>
-            <tcp-ip enabled="false" />
-            <discovery-strategies>
-              <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-              </discovery-strategy>
-            </discovery-strategies>
-          </join>
-        </network>
-
-        <management-center enabled="${hazelcast.mancenter.enabled}">${hazelcast.mancenter.url}</management-center>
-
+   yaml:
+    hazelcast:
+      network:
+        join:
+          multicast:
+            enabled: false
+          kubernetes:
+            enabled: true
+            service-name: ${serviceName}
+            namespace: ${namespace}
+            resolve-not-ready-addresses: true
         <!-- Custom Configuration Placeholder -->
-      </hazelcast>
 ```

--- a/stable/hazelcast/templates/config.yaml
+++ b/stable/hazelcast/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.hazelcast.configurationFiles .Values.hazelcast.yaml }}
+{{- if and (or .Values.hazelcast.configurationFiles .Values.hazelcast.yaml) (not .Values.hazelcast.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -53,9 +53,11 @@ spec:
         ports:
         - name: hazelcast
           containerPort: 5701
+          hostPort: {{ .Values.hostPort }}
         {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: {{ .Values.metrics.service.port }}
+
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
@@ -112,7 +114,11 @@ spec:
       volumes:
       - name: hazelcast-storage
         configMap:
+          {{- if .Values.hazelcast.existingConfigMap }}
+          name: {{ .Values.hazelcast.existingConfigMap }}
+          {{- else }}
           name: {{ template "hazelcast.fullname" . }}-configuration
+          {{- end }}
       {{- if .Values.customVolume }}
       - name: hazelcast-custom
 {{ toYaml .Values.customVolume | indent 8 }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -57,7 +57,6 @@ spec:
         {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: {{ .Values.metrics.service.port }}
-
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -28,6 +28,8 @@ hazelcast:
   rest: true
   # javaOpts are additional JAVA_OPTS properties for Hazelcast member
   javaOpts:
+  # existingConfigMap defines a ConfigMap which contains Hazelcast configuration file(s) that are used instead hazelcast.yaml configuration below
+  # existingConfigMap
   # yaml is the Hazelcast YAML configuration file
   yaml:
     hazelcast:
@@ -50,6 +52,9 @@ hazelcast:
 # nodeSelector is an array of Hazelcast Node labels for POD assignments
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
+
+# hostPort is a port under which Hazelcast PODs are exposed on the host machines
+# hostPort:
 
 gracefulShutdown:
   enabled: true


### PR DESCRIPTION
This PR adds to features to our Helm Chart. Both are disabled by default.
- `hostPort` - if you specify the variable `hostPort` then your PODs are exposed on the host network under the specified port
- `hazelcast.existingConfigMap` - option to define the Hazelcast Configuration outside the Helm Chart, then the `hazelcast.yaml` part of `values.yaml` is ignored and the ConfigMap with the name specified is used instead