### PR TITLE
Jet Chart Improvements

### DIFF
--- a/stable/hazelcast-jet-enterprise/Chart.yaml
+++ b/stable/hazelcast-jet-enterprise/Chart.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
-appVersion: "3.0"
+appVersion: "3.1"
+tillerVersion: ">=2.7.2"
+kubeVersion: ">=1.9.0-0"
 description: Hazelcast Jet Enterprise provides critical management features for scaling in-memory event stream processing across your IT landscape, including Management Center, Security Suite, Lossless Recovery, Rolling Job upgrades, and Enterprise PaaS Deployment Environments.
 name: hazelcast-jet-enterprise
-version: 1.0.4
+version: 1.1.0
 keywords:
 - hazelcast
 - jet

--- a/stable/hazelcast-jet-enterprise/README.md
+++ b/stable/hazelcast-jet-enterprise/README.md
@@ -85,6 +85,10 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `securityContext.enabled`                  | Enables Security Context for Hazelcast Jet and Hazelcast Jet Management Center                                 | `true`                                               |
 | `securityContext.runAsUser`                | User ID used to run the Hazelcast Jet and Hazelcast Jet Management Center containers                           | `1001`                                               |
 | `securityContext.fsGroup`                  | Group ID associated with the Hazelcast Jet and Hazelcast Jet Management Center container                       | `1001`                                               |
+| `metrics.enabled`                          | Turn on and off JMX Prometheus metrics available at `/metrics`                                                 | `false`                                              |
+| `metrics.service.type`                     | Type of the metrics service                                                                                    | `ClusterIP`                                          |
+| `metrics.service.port`                     | Port of the `/metrics` endpoint and the metrics service                                                        | `8080`                                               |
+| `metrics.service.annotations`              | Annotations for the Prometheus discovery                                                                       |                                                      |
 | `managementcenter.enabled`                        | Turn on and off Hazelcast Jet Management Center application                                             | `true`                                               |
 | `managementcenter.image.repository`               | Hazelcast Jet Management Center Image name                                                              | `hazelcast/hazelcast-jet-management-center`                        |
 | `managementcenter.image.tag`                      | Hazelcast Jet Management Center Image tag (NOTE: must be the same or one minor release greater than Hazelcast image version) | `{VERSION}`                                  |
@@ -130,72 +134,57 @@ $ helm install --name my-release -f values.yaml hazelcast/hazelcast-jet-enterpri
 
 ## Custom Hazelcast IMDG and Jet configuration
 
-Custom Hazelcast IMDG and Hazelcast Jet configuration can be specified inside `values.yaml`, as the `jet.configurationFiles.hazelcast.xml` and `jet.configurationFiles.hazelcast-jet.xml` properties.
+Custom Hazelcast IMDG and Hazelcast Jet configuration can be specified inside `values.yaml`, as the `jet.configurationFiles.hazelcast.yaml` and `jet.configurationFiles.hazelcast-jet.yaml` properties.
 
 ```yaml
 jet:
   configurationFiles:
-    hazelcast.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-                     xmlns="http://www.hazelcast.com/schema/config"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <license-key>ENTER LICENSE KEY HERE</license-key>
-        <network>
-          <join>
-            <multicast enabled="false"/>
-            <tcp-ip enabled="false" />
-            <discovery-strategies>
-              <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-                <properties>
-                  <property name="service-name">${serviceName}</property>
-                  <property name="namespace">${namespace}</property>
-                </properties>
-              </discovery-strategy>
-            </discovery-strategies>
-          </join>
-        </network>
-        <!-- Custom Configuration Placeholder -->
-      </hazelcast>
-    hazelcast-jet.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-0.8.xsd"
-                    xmlns="http://www.hazelcast.com/schema/jet-config"
-                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <instance>
-              <!-- number of threads in the cooperative thread pool -->
-            <cooperative-thread-count>8</cooperative-thread-count>
-              <!-- period between flow control packets in milliseconds -->
-            <flow-control-period>100</flow-control-period>
-              <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
-            <backup-count>1</backup-count>
-          </instance>
-          <!-- custom properties which can be read in the user code -->
-          <properties>
-            <property name="custom.property">custom property</property>
-          </properties>
-          <edge-defaults>
-              <!-- capacity of the concurrent SPSC queue between each two processors -->
-            <queue-size>1024</queue-size>
-              <!-- network packet size limit in bytes, only applies to distributed edges -->
-            <packet-size-limit>16384</packet-size-limit>
-              <!-- receive window size multiplier, only applies to distributed edges -->
-            <receive-window-multiplier>3</receive-window-multiplier>
-          </edge-defaults>
-          <!-- whether metrics collection is enabled -->
-          <metrics enabled="true">
-              <!-- the number of seconds the metrics will be retained on the instance -->
-              <retention-seconds>120</retention-seconds>
-              <!-- the metrics collection interval in seconds -->
-              <collection-interval-seconds>5</collection-interval-seconds>
-              <!-- whether metrics should be collected for data structures. Metrics
-                  collection can have some overhead if there is a large number of data
-                  structures -->
-              <metrics-for-data-structures>false</metrics-for-data-structures>
-          </metrics>
-      </hazelcast-jet>
+    hazelcast.yaml: |-
+      hazelcast:
+        license-key: Your Hazelcast Jet Enterprise License Key
+        network:
+          join:
+            multicast:
+              enabled: false
+            kubernetes:
+              enabled: true
+              namespace: ${namespace}
+              service-name: ${serviceName}
+              resolve-not-ready-addresses: true
+    hazelcast-jet.yaml: |-
+      hazelcast-jet:
+        instance:
+          # period between flow control packets in milliseconds
+          flow-control-period: 100
+          # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
+          backup-count: 1
+          # the delay after which auto-scaled jobs will restart if a new member is added to the
+          # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
+          scale-up-delay-millis: 10000
+          # Sets whether lossless job restart is enabled for the node. With
+          # lossless restart you can restart the whole cluster without losing the
+          # jobs and their state. The feature is implemented on top of the Hot
+          # Restart feature of Hazelcast IMDG which persists the data to disk.
+          lossless-restart-enabled: false
+        edge-defaults:
+          # capacity of the concurrent SPSC queue between each two processors
+          queue-size: 1024
+          # network packet size limit in bytes, only applies to distributed edges
+          packet-size-limit: 16384
+          # receive window size multiplier, only applies to distributed edges
+          receive-window-multiplier: 3
+        metrics:
+          # whether metrics collection is enabled
+          enabled: true
+          # whether jmx mbean metrics collection is enabled
+          jmx-enabled: true
+          # the number of seconds the metrics will be retained on the instance
+          retention-seconds: 120
+          # the metrics collection interval in seconds
+          collection-interval-seconds: 5
+          # whether metrics should be collected for data structures. Metrics
+          # collection can have some overhead if there is a large number of data
+          # structures
+          metrics-for-data-structures: false
+      
 ```

--- a/stable/hazelcast-jet-enterprise/metrics-service.yaml
+++ b/stable/hazelcast-jet-enterprise/metrics-service.yaml
@@ -1,23 +1,23 @@
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "hazelcast-jet-management-center.fullname" . }}
+  name: {{ template "hazelcast-jet.fullname" . }}-metrics
   labels:
     app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
     helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.metrics.service.annotations | indent 4 }}
 spec:
-  type: {{ .Values.managementcenter.service.type }}
-  {{- if .Values.managementcenter.service.clusterIP }}
-  clusterIP: {{ .Values.managementcenter.service.clusterIP }}
-  {{- end }}
+  type: {{ .Values.metrics.service.type }}
   selector:
     app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
-    role: hazelcast-jet-management-center
   ports:
   - protocol: TCP
-    port: {{ .Values.managementcenter.service.port }}
-    targetPort: mc-port
-    name: mc-port
+    port: {{ .Values.metrics.service.port }}
+    targetPort: metrics
+    name: metrics
+{{- end }}

--- a/stable/hazelcast-jet-enterprise/templates/NOTES.txt
+++ b/stable/hazelcast-jet-enterprise/templates/NOTES.txt
@@ -3,11 +3,11 @@
 -------------------------------------------------------------------------------
 To access Hazelcast Jet within the Kubernetes cluster:
 
-- Use Hazelcast Jet Client with Kubernetes Discovery Strategy pointing to DNS: {{ template "hazelcast-jet.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local. Read more at: https://github.com/hazelcast/hazelcast-kubernetes.
+- Use Hazelcast Jet Client with Kubernetes Discovery Strategy. Read more at: https://github.com/hazelcast/hazelcast-kubernetes.
 
 {{- if .Values.jet.rest }}
 - Use REST healtcheck endpoint:
-  $ curl http://{{ template "hazelcast-jet.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5701/hazelcast/health
+  $ curl http://{{ template "hazelcast-jet.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/hazelcast/health
 {{- end }}
 
 -------------------------------------------------------------------------------
@@ -23,8 +23,8 @@ To access Hazelcast Jet from outside the Kubernetes cluster:
      clientConfig.getNetworkConfig().addAddress("$SERVICE_IP:{{ .Values.service.port }}");
 {{- else if contains "ClusterIP" .Values.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:5701
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:{{ .Values.service.port }}
   *) In Hazelcast Jet Client configure:
      clientConfig.getNetworkConfig().setSmartRouting(false);
      clientConfig.getNetworkConfig().addAddress("127.0.0.1:5701");
@@ -47,8 +47,8 @@ To access Hazelcast Jet from outside the Kubernetes cluster:
      $ curl http://$SERVICE_IP:{{ .Values.service.port }}/hazelcast/health
 {{- else if contains "ClusterIP" .Values.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:5701
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:{{ .Values.service.port }}
   *) Get health info:
      $ curl http://127.0.0.1:5701/hazelcast/health
 {{- else if contains "NodePort" .Values.service.type }}
@@ -73,7 +73,7 @@ To access Hazelcast Jet Management Center:
   *) Open Browser at: http://$MANAGEMENT_CENTER_IP:{{ .Values.managementcenter.service.port }}/
 {{- else if contains "ClusterIP" .Values.managementcenter.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast-jet.name" . }},role=hazelcast-jet-management-center" -o jsonpath="{.items[0].metadata.name}")
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast-jet.name" . }},role=hazelcast-jet-management-center" -o jsonpath="{.items[0].metadata.name}")
      $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 8081:8081
   *) Open Browser at: http://127.0.0.1:8081
 {{- else if contains "NodePort" .Values.managementcenter.service.type }}

--- a/stable/hazelcast-jet-enterprise/templates/_helpers.tpl
+++ b/stable/hazelcast-jet-enterprise/templates/_helpers.tpl
@@ -25,10 +25,10 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Create chart name as used by the chart label.
 */}}
 {{- define "hazelcast-jet.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/hazelcast-jet-enterprise/templates/config.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/config.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}-configuration
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 data:
 {{- range $key, $val := .Values.jet.configurationFiles }}
   {{ $key }}: |-

--- a/stable/hazelcast-jet-enterprise/templates/management-center-config.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/management-center-config.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "hazelcast-jet-management-center.fullname" . }}-configuration
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 data:
 {{- range $key, $val := .Values.managementcenter.configurationFiles }}
   {{ $key }}: |-

--- a/stable/hazelcast-jet-enterprise/templates/management-center-deployment.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/management-center-deployment.yaml
@@ -4,22 +4,26 @@ kind: Deployment
 metadata:
   name: {{ template "hazelcast-jet-management-center.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "hazelcast-jet.name" . }}
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+      helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/managed-by: "{{ .Release.Service }}"
       role: hazelcast-jet-management-center
   template:
     metadata:
       labels:
-        app: {{ template "hazelcast-jet.name" . }}
-        release: "{{ .Release.Name }}"
+        app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+        helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: hazelcast-jet-management-center
     spec:
       {{- if .Values.managementcenter.image.pullSecrets }}
@@ -89,7 +93,7 @@ spec:
           value: {{ .Values.jet.licenseKey }}
         {{- end }}
         - name: JAVA_OPTS
-          value: " -Djet.clientConfig=/data/hazelcast-jet-management-center/hazelcast-client.xml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }} {{ .Values.managementcenter.javaOpts }}"
+          value: " -Djet.clientConfig=/data/hazelcast-jet-management-center/hazelcast-client.yaml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }} {{ .Values.managementcenter.javaOpts }}"
       serviceAccountName: {{ template "hazelcast-jet.serviceAccountName" . }}
       volumes:
       - name: hazelcast-jet-management-center-storage

--- a/stable/hazelcast-jet-enterprise/templates/role.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/role.yaml
@@ -1,19 +1,20 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
   - pods
+  - nodes
   verbs:
   - get
   - list

--- a/stable/hazelcast-jet-enterprise/templates/rolebinding.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/rolebinding.yaml
@@ -1,16 +1,16 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ template "hazelcast-jet.fullname" . }}
 subjects:
 - kind: ServiceAccount

--- a/stable/hazelcast-jet-enterprise/templates/service.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/service.yaml
@@ -3,18 +3,18 @@ kind: Service
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   selector:
-    app: {{ template "hazelcast-jet.name" . }}
-    release: "{{ .Release.Name }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:
   - protocol: TCP
     port: {{ .Values.service.port }}

--- a/stable/hazelcast-jet-enterprise/templates/serviceaccount.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/serviceaccount.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "hazelcast-jet.serviceAccountName" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- end -}}

--- a/stable/hazelcast-jet-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/statefulset.yaml
@@ -3,21 +3,28 @@ kind: StatefulSet
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
+  serviceName: {{ template "hazelcast-jet.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}
   selector:
     matchLabels:
-      app: {{ template "hazelcast-jet.name" . }}
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+      helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+      role: hazelcast-jet
   template:
     metadata:
       labels:
-        app: {{ template "hazelcast-jet.name" . }}
-        release: "{{ .Release.Name }}"
+        app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+        helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        role: hazelcast-jet
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -41,6 +48,10 @@ spec:
         ports:
         - name: hazelcast-jet
           containerPort: 5701
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: {{ .Values.metrics.service.port }}
+        {{- end }}          
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
@@ -67,6 +78,10 @@ spec:
         - name: hazelcast-jet-storage
           mountPath: /data/hazelcast-jet
         env:
+        {{- if .Values.metrics.enabled }}
+        - name: PROMETHEUS_PORT
+          value: "{{ .Values.metrics.service.port }}"
+        {{- end }}
         - name: JET_LICENSE_KEY
         {{- if .Values.jet.licenseKeySecretName }}
           valueFrom:
@@ -77,7 +92,7 @@ spec:
           value: {{ .Values.jet.licenseKey }}
         {{- end }}
         - name: JAVA_OPTS
-          value: "-Dhazelcast.rest.enabled={{ .Values.jet.rest }} -Dhazelcast.config=/data/hazelcast-jet/hazelcast.xml -Dhazelcast.jet.config=/data/hazelcast-jet/hazelcast-jet.xml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }} {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ .Values.jet.javaOpts }}"
+          value: "-Dhazelcast.rest.enabled={{ .Values.jet.rest }} -Dhazelcast.config=/data/hazelcast-jet/hazelcast.yaml -Dhazelcast.jet.config=/data/hazelcast-jet/hazelcast-jet.yaml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }} {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.jet.javaOpts }}"
       serviceAccountName: {{ template "hazelcast-jet.serviceAccountName" . }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/stable/hazelcast-jet-enterprise/templates/tests/test-hazelcast-jet.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/tests/test-hazelcast-jet.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "hazelcast-jet.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    app.kubernetes.io/component: "test"
+    role: test
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+  containers:
+  - name: "{{ template "hazelcast-jet.fullname" . }}-test"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # Get the number of Hazelcast members in the cluster
+      CLUSTER_SIZE=$(curl {{ template "hazelcast-jet.fullname" . }}:{{ .Values.service.port }}/hazelcast/health/cluster-size)
+      # Test the currect number of Hazelcast members
+      test ${CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  restartPolicy: Never

--- a/stable/hazelcast-jet-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/tests/test-management-center.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "hazelcast-jet-management-center.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    app.kubernetes.io/component: "test"
+    role: test
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+  containers:
+  - name: "{{ template "hazelcast-jet-management-center.fullname" . }}-test"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # Get the HTTP Response Code of the Deployment
+      HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "hazelcast-jet-management-center.fullname" . }}:{{ .Values.managementcenter.service.port }}/login)
+      test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  restartPolicy: Never

--- a/stable/hazelcast-jet-enterprise/values.yaml
+++ b/stable/hazelcast-jet-enterprise/values.yaml
@@ -5,7 +5,7 @@ image:
   # repository is the Hazelcast Jet Enterprise image name
   repository: "hazelcast/hazelcast-jet-enterprise"
   # tag is the Hazelcast Jet image tag
-  tag: "3.0"
+  tag: "3.1"
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -34,66 +34,51 @@ jet:
   javaOpts:
   # configurationFiles are Hazelcast Jet configuration files
   configurationFiles:
-    hazelcast.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-                     xmlns="http://www.hazelcast.com/schema/config"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <network>
-          <join>
-            <multicast enabled="false"/>
-            <tcp-ip enabled="false" />
-            <discovery-strategies>
-              <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-                <properties>
-                  <property name="service-name">${serviceName}</property>
-                  <property name="namespace">${namespace}</property>
-                </properties>
-              </discovery-strategy>
-            </discovery-strategies>
-          </join>
-        </network>
-      </hazelcast>
-    hazelcast-jet.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-0.8.xsd"
-                    xmlns="http://www.hazelcast.com/schema/jet-config"
-                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <instance>
-              <!-- number of threads in the cooperative thread pool -->
-            <cooperative-thread-count>8</cooperative-thread-count>
-              <!-- period between flow control packets in milliseconds -->
-            <flow-control-period>100</flow-control-period>
-              <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
-            <backup-count>1</backup-count>
-          </instance>
-          <!-- custom properties which can be read in the user code -->
-          <properties>
-            <property name="custom.property">custom property</property>
-          </properties>
-          <edge-defaults>
-              <!-- capacity of the concurrent SPSC queue between each two processors -->
-            <queue-size>1024</queue-size>
-              <!-- network packet size limit in bytes, only applies to distributed edges -->
-            <packet-size-limit>16384</packet-size-limit>
-              <!-- receive window size multiplier, only applies to distributed edges -->
-            <receive-window-multiplier>3</receive-window-multiplier>
-          </edge-defaults>
-          <!-- whether metrics collection is enabled -->
-          <metrics enabled="true">
-              <!-- the number of seconds the metrics will be retained on the instance -->
-              <retention-seconds>120</retention-seconds>
-              <!-- the metrics collection interval in seconds -->
-              <collection-interval-seconds>5</collection-interval-seconds>
-              <!-- whether metrics should be collected for data structures. Metrics
-                  collection can have some overhead if there is a large number of data
-                  structures -->
-              <metrics-for-data-structures>false</metrics-for-data-structures>
-          </metrics>
-      </hazelcast-jet>
+    hazelcast.yaml: |-
+      hazelcast:
+        network:
+          join:
+            multicast:
+              enabled: false
+            kubernetes:
+              enabled: true
+              namespace: ${namespace}
+              service-name: ${serviceName}
+    hazelcast-jet.yaml: |-
+      hazelcast-jet:
+        instance:
+          # period between flow control packets in milliseconds
+          flow-control-period: 100
+          # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
+          backup-count: 1
+          # the delay after which auto-scaled jobs will restart if a new member is added to the
+          # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
+          scale-up-delay-millis: 10000
+          # Sets whether lossless job restart is enabled for the node. With
+          # lossless restart you can restart the whole cluster without losing the
+          # jobs and their state. The feature is implemented on top of the Hot
+          # Restart feature of Hazelcast IMDG which persists the data to disk.
+          lossless-restart-enabled: false
+        edge-defaults:
+          # capacity of the concurrent SPSC queue between each two processors
+          queue-size: 1024
+          # network packet size limit in bytes, only applies to distributed edges
+          packet-size-limit: 16384
+          # receive window size multiplier, only applies to distributed edges
+          receive-window-multiplier: 3
+        metrics:
+          # whether metrics collection is enabled
+          enabled: true
+          # whether jmx mbean metrics collection is enabled
+          jmx-enabled: true
+          # the number of seconds the metrics will be retained on the instance
+          retention-seconds: 120
+          # the metrics collection interval in seconds
+          collection-interval-seconds: 5
+          # whether metrics should be collected for data structures. Metrics
+          # collection can have some overhead if there is a large number of data
+          # structures
+          metrics-for-data-structures: false
       
 # nodeSelector is an array of Hazelcast Node labels for POD assignments
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -174,6 +159,16 @@ securityContext:
   # fsGroup is the group ID associated with the container
   fsGroup: 1001
 
+# Allows to enable a Prometheus to scrape pods
+metrics:
+  enabled: false
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/path: "/metrics"
+
 # Hazelcast Jet Management Center application properties
 managementcenter:
   # enabled is a flag to enable Hazelcast Jet Management Center application
@@ -185,7 +180,7 @@ managementcenter:
     # repository is the Hazelcast Jet Management Center image name
     repository: "hazelcast/hazelcast-jet-management-center"
     # tag is the Hazelcast Jet Management Center image tag
-    tag: "3.0"
+    tag: "3.1"
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -212,25 +207,13 @@ managementcenter:
 
   # configurationFiles are Hazelcast Jet Client configuration files which will be used by Hazelcast Jet Management Center
   configurationFiles:
-    hazelcast-client.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                        xmlns="http://www.hazelcast.com/schema/client-config"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <network>
-          <discovery-strategies>
-            <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-              <properties>
-                <property name="service-name">${serviceName}</property>
-                <property name="namespace">${namespace}</property>
-              </properties>
-            </discovery-strategy>
-          </discovery-strategies>
-        </network>
-      </hazelcast-client>
+    hazelcast-client.yaml: |-
+      hazelcast-client:
+        network:
+          kubernetes:
+            enabled: true
+            namespace: ${namespace}
+            service-name: ${serviceName}
 
   # Configure resource requests and limits
   # ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/hazelcast-jet/Chart.yaml
+++ b/stable/hazelcast-jet/Chart.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
-appVersion: "3.0"
+appVersion: "3.1"
+tillerVersion: ">=2.7.2"
+kubeVersion: ">=1.9.0-0"
 description: Hazelcast Jet is an application embeddable, distributed computing engine built on top of Hazelcast In-Memory Data Grid (IMDG). With Hazelcast IMDG providing storage functionality, Hazelcast Jet performs parallel execution to enable data-intensive applications to operate in near real-time.
 name: hazelcast-jet
-version: 1.0.4
+version: 1.1.0
 keywords:
 - hazelcast
 - jet

--- a/stable/hazelcast-jet/templates/NOTES.txt
+++ b/stable/hazelcast-jet/templates/NOTES.txt
@@ -3,16 +3,16 @@
 -------------------------------------------------------------------------------
 To access Hazelcast Jet within the Kubernetes cluster:
 
-- Use Hazelcast Jet Client with Kubernetes Discovery Strategy pointing to DNS: {{ template "hazelcast-jet.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local. Read more at: https://github.com/hazelcast/hazelcast-kubernetes.
+- Use Hazelcast Jet Client with Kubernetes Discovery Strategy. Read more at: https://github.com/hazelcast/hazelcast-kubernetes.
 
 {{- if .Values.jet.rest }}
 - Use REST healtcheck endpoint:
-  $ curl http://{{ template "hazelcast-jet.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5701/hazelcast/health
+  $ curl http://{{ template "hazelcast-jet.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/hazelcast/health
 {{- end }}
 
 -------------------------------------------------------------------------------
 
-To access Hazelcast from outside the Kubernetes cluster:
+To access Hazelcast Jet from outside the Kubernetes cluster:
 
 - Use Hazelcast Jet Client with Smart Routing disabled:
 {{- if contains "LoadBalancer" .Values.service.type }}
@@ -23,8 +23,8 @@ To access Hazelcast from outside the Kubernetes cluster:
      clientConfig.getNetworkConfig().addAddress("$SERVICE_IP:{{ .Values.service.port }}");
 {{- else if contains "ClusterIP" .Values.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:5701
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:{{ .Values.service.port }}
   *) In Hazelcast Jet Client configure:
      clientConfig.getNetworkConfig().setSmartRouting(false);
      clientConfig.getNetworkConfig().addAddress("127.0.0.1:5701");
@@ -47,8 +47,8 @@ To access Hazelcast from outside the Kubernetes cluster:
      $ curl http://$SERVICE_IP:{{ .Values.service.port }}/hazelcast/health
 {{- else if contains "ClusterIP" .Values.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
-     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:5701
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast-jet.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+     $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 5701:{{ .Values.service.port }}
   *) Get health info:
      $ curl http://127.0.0.1:5701/hazelcast/health
 {{- else if contains "NodePort" .Values.service.type }}
@@ -73,7 +73,7 @@ To access Hazelcast Jet Management Center:
   *) Open Browser at: http://$MANAGEMENT_CENTER_IP:{{ .Values.managementcenter.service.port }}/
 {{- else if contains "ClusterIP" .Values.managementcenter.service.type }}
   *) Forward port from POD:
-     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "hazelcast-jet.name" . }},role=hazelcast-jet-management-center" -o jsonpath="{.items[0].metadata.name}")
+     $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast-jet.name" . }},role=hazelcast-jet-management-center" -o jsonpath="{.items[0].metadata.name}")
      $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 8081:8081
   *) Open Browser at: http://127.0.0.1:8081
 {{- else if contains "NodePort" .Values.managementcenter.service.type }}

--- a/stable/hazelcast-jet/templates/_helpers.tpl
+++ b/stable/hazelcast-jet/templates/_helpers.tpl
@@ -25,10 +25,10 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Create chart name as used by the chart label.
 */}}
 {{- define "hazelcast-jet.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/hazelcast-jet/templates/config.yaml
+++ b/stable/hazelcast-jet/templates/config.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}-configuration
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 data:
 {{- range $key, $val := .Values.jet.configurationFiles }}
   {{ $key }}: |-

--- a/stable/hazelcast-jet/templates/management-center-config.yaml
+++ b/stable/hazelcast-jet/templates/management-center-config.yaml
@@ -4,10 +4,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "hazelcast-jet-management-center.fullname" . }}-configuration
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 data:
 {{- range $key, $val := .Values.managementcenter.configurationFiles }}
   {{ $key }}: |-

--- a/stable/hazelcast-jet/templates/management-center-deployment.yaml
+++ b/stable/hazelcast-jet/templates/management-center-deployment.yaml
@@ -4,22 +4,26 @@ kind: Deployment
 metadata:
   name: {{ template "hazelcast-jet-management-center.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ template "hazelcast-jet.name" . }}
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+      helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/managed-by: "{{ .Release.Service }}"
       role: hazelcast-jet-management-center
   template:
     metadata:
       labels:
-        app: {{ template "hazelcast-jet.name" . }}
-        release: "{{ .Release.Name }}"
+        app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+        helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: hazelcast-jet-management-center
     spec:
       {{- if .Values.managementcenter.image.pullSecrets }}
@@ -82,7 +86,7 @@ spec:
           value: {{ .Values.managementcenter.licenseKey }}
         {{- end }}
         - name: JAVA_OPTS
-          value: " -Djet.clientConfig=/data/hazelcast-jet-management-center/hazelcast-client.xml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }} {{ .Values.managementcenter.javaOpts }}"
+          value: " -Djet.clientConfig=/data/hazelcast-jet-management-center/hazelcast-client.yaml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }} {{ .Values.managementcenter.javaOpts }}"
       serviceAccountName: {{ template "hazelcast-jet.serviceAccountName" . }}
       volumes:
       - name: hazelcast-jet-management-center-storage

--- a/stable/hazelcast-jet/templates/management-center-service.yaml
+++ b/stable/hazelcast-jet/templates/management-center-service.yaml
@@ -3,18 +3,18 @@ kind: Service
 metadata:
   name: {{ template "hazelcast-jet-management-center.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.managementcenter.service.type }}
   {{- if .Values.managementcenter.service.clusterIP }}
   clusterIP: {{ .Values.managementcenter.service.clusterIP }}
   {{- end }}
   selector:
-    app: {{ template "hazelcast-jet.name" . }}
-    release: "{{ .Release.Name }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
     role: hazelcast-jet-management-center
   ports:
   - protocol: TCP

--- a/stable/hazelcast-jet/templates/metrics-service.yaml
+++ b/stable/hazelcast-jet/templates/metrics-service.yaml
@@ -1,23 +1,23 @@
+{{- if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "hazelcast-jet-management-center.fullname" . }}
+  name: {{ template "hazelcast-jet.fullname" . }}-metrics
   labels:
     app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
     helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.metrics.service.annotations | indent 4 }}
 spec:
-  type: {{ .Values.managementcenter.service.type }}
-  {{- if .Values.managementcenter.service.clusterIP }}
-  clusterIP: {{ .Values.managementcenter.service.clusterIP }}
-  {{- end }}
+  type: {{ .Values.metrics.service.type }}
   selector:
     app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
-    role: hazelcast-jet-management-center
   ports:
   - protocol: TCP
-    port: {{ .Values.managementcenter.service.port }}
-    targetPort: mc-port
-    name: mc-port
+    port: {{ .Values.metrics.service.port }}
+    targetPort: metrics
+    name: metrics
+{{- end }}

--- a/stable/hazelcast-jet/templates/role.yaml
+++ b/stable/hazelcast-jet/templates/role.yaml
@@ -1,19 +1,20 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 rules:
 - apiGroups:
   - ""
   resources:
   - endpoints
   - pods
+  - nodes
   verbs:
   - get
   - list

--- a/stable/hazelcast-jet/templates/rolebinding.yaml
+++ b/stable/hazelcast-jet/templates/rolebinding.yaml
@@ -1,16 +1,16 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ template "hazelcast-jet.fullname" . }}
 subjects:
 - kind: ServiceAccount

--- a/stable/hazelcast-jet/templates/service.yaml
+++ b/stable/hazelcast-jet/templates/service.yaml
@@ -3,18 +3,18 @@ kind: Service
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   type: {{ .Values.service.type }}
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
   selector:
-    app: {{ template "hazelcast-jet.name" . }}
-    release: "{{ .Release.Name }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
   ports:
   - protocol: TCP
     port: {{ .Values.service.port }}

--- a/stable/hazelcast-jet/templates/serviceaccount.yaml
+++ b/stable/hazelcast-jet/templates/serviceaccount.yaml
@@ -4,8 +4,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "hazelcast-jet.serviceAccountName" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- end -}}

--- a/stable/hazelcast-jet/templates/statefulset.yaml
+++ b/stable/hazelcast-jet/templates/statefulset.yaml
@@ -3,21 +3,28 @@ kind: StatefulSet
 metadata:
   name: {{ template "hazelcast-jet.fullname" . }}
   labels:
-    app: {{ template "hazelcast-jet.name" . }}
-    chart: {{ template "hazelcast-jet.chart" . }}
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
+  serviceName: {{ template "hazelcast-jet.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}
   selector:
     matchLabels:
-      app: {{ template "hazelcast-jet.name" . }}
-      release: "{{ .Release.Name }}"
+      app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+      helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
+      app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+      role: hazelcast-jet
   template:
     metadata:
       labels:
-        app: {{ template "hazelcast-jet.name" . }}
-        release: "{{ .Release.Name }}"
+        app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+        helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        role: hazelcast-jet
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
@@ -41,6 +48,10 @@ spec:
         ports:
         - name: hazelcast-jet
           containerPort: 5701
+        {{- if .Values.metrics.enabled }}
+        - name: metrics
+          containerPort: {{ .Values.metrics.service.port }}
+        {{- end }}          
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
@@ -67,8 +78,12 @@ spec:
         - name: hazelcast-jet-storage
           mountPath: /data/hazelcast-jet
         env:
+        {{- if .Values.metrics.enabled }}
+        - name: PROMETHEUS_PORT
+          value: "{{ .Values.metrics.service.port }}"
+        {{- end }}
         - name: JAVA_OPTS
-          value: "-Dhazelcast.rest.enabled={{ .Values.jet.rest }} -Dhazelcast.config=/data/hazelcast-jet/hazelcast.xml -Dhazelcast.jet.config=/data/hazelcast-jet/hazelcast-jet.xml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }}  {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ .Values.jet.javaOpts }}"
+          value: "-Dhazelcast.rest.enabled={{ .Values.jet.rest }} -Dhazelcast.config=/data/hazelcast-jet/hazelcast.yaml -Dhazelcast.jet.config=/data/hazelcast-jet/hazelcast-jet.yaml -DserviceName={{ template "hazelcast-jet.fullname" . }} -Dnamespace={{ .Release.Namespace }}  {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }}  {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.jet.javaOpts }}"
       serviceAccountName: {{ template "hazelcast-jet.serviceAccountName" . }}
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/stable/hazelcast-jet/templates/tests/test-hazelcast-jet.yaml
+++ b/stable/hazelcast-jet/templates/tests/test-hazelcast-jet.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "hazelcast-jet.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    app.kubernetes.io/component: "test"
+    role: test
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+  containers:
+  - name: "{{ template "hazelcast-jet.fullname" . }}-test"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # Get the number of Hazelcast members in the cluster
+      CLUSTER_SIZE=$(curl {{ template "hazelcast-jet.fullname" . }}:{{ .Values.service.port }}/hazelcast/health/cluster-size)
+      # Test the currect number of Hazelcast members
+      test ${CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  restartPolicy: Never

--- a/stable/hazelcast-jet/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-jet/templates/tests/test-management-center.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ template "hazelcast-jet-management-center.fullname" . }}-test-{{ randAlphaNum 5 | lower }}"
+  annotations:
+    "helm.sh/hook": test-success
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast-jet.name" . }}
+    helm.sh/chart: {{ template "hazelcast-jet.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    app.kubernetes.io/component: "test"
+    role: test
+spec:
+  hostNetwork: false
+  hostPID: false
+  hostIPC: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+  containers:
+  - name: "{{ template "hazelcast-jet-management-center.fullname" . }}-test"
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+    command:
+    - "bash"
+    - "-c"
+    - |
+      set -ex
+      # Get the HTTP Response Code of the Deployment
+      HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "hazelcast-jet-management-center.fullname" . }}:{{ .Values.managementcenter.service.port }}/login)
+      test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      privileged: false
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+  restartPolicy: Never

--- a/stable/hazelcast-jet/values.yaml
+++ b/stable/hazelcast-jet/values.yaml
@@ -5,7 +5,7 @@ image:
   # repository is the Hazelcast Jet image name
   repository: "hazelcast/hazelcast-jet"
   # tag is the Hazelcast Jet image tag
-  tag: "3.0"
+  tag: "3.1"
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -30,66 +30,52 @@ jet:
   javaOpts:
   # configurationFiles are Hazelcast Jet configuration files
   configurationFiles:
-    hazelcast.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.10.xsd"
-                     xmlns="http://www.hazelcast.com/schema/config"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <network>
-          <join>
-            <multicast enabled="false"/>
-            <tcp-ip enabled="false" />
-            <discovery-strategies>
-              <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-                <properties>
-                  <property name="service-name">${serviceName}</property>
-                  <property name="namespace">${namespace}</property>
-                </properties>
-              </discovery-strategy>
-            </discovery-strategies>
-          </join>
-        </network>
-      </hazelcast>
-    hazelcast-jet.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-0.8.xsd"
-                    xmlns="http://www.hazelcast.com/schema/jet-config"
-                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-          <instance>
-              <!-- number of threads in the cooperative thread pool -->
-            <cooperative-thread-count>8</cooperative-thread-count>
-              <!-- period between flow control packets in milliseconds -->
-            <flow-control-period>100</flow-control-period>
-              <!-- number of backup copies to configure for Hazelcast IMaps used internally in a Jet job -->
-            <backup-count>1</backup-count>
-          </instance>
-          <!-- custom properties which can be read in the user code -->
-          <properties>
-            <property name="custom.property">custom property</property>
-          </properties>
-          <edge-defaults>
-              <!-- capacity of the concurrent SPSC queue between each two processors -->
-            <queue-size>1024</queue-size>
-              <!-- network packet size limit in bytes, only applies to distributed edges -->
-            <packet-size-limit>16384</packet-size-limit>
-              <!-- receive window size multiplier, only applies to distributed edges -->
-            <receive-window-multiplier>3</receive-window-multiplier>
-          </edge-defaults>
-          <!-- whether metrics collection is enabled -->
-          <metrics enabled="true">
-              <!-- the number of seconds the metrics will be retained on the instance -->
-              <retention-seconds>120</retention-seconds>
-              <!-- the metrics collection interval in seconds -->
-              <collection-interval-seconds>5</collection-interval-seconds>
-              <!-- whether metrics should be collected for data structures. Metrics
-                  collection can have some overhead if there is a large number of data
-                  structures -->
-              <metrics-for-data-structures>false</metrics-for-data-structures>
-          </metrics>
-      </hazelcast-jet>
+    hazelcast.yaml: |-
+      hazelcast:
+        network:
+          join:
+            multicast:
+              enabled: false
+            kubernetes:
+              enabled: true
+              namespace: ${namespace}
+              service-name: ${serviceName}
+              resolve-not-ready-addresses: true
+    hazelcast-jet.yaml: |-
+      hazelcast-jet:
+        instance:
+          # period between flow control packets in milliseconds
+          flow-control-period: 100
+          # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
+          backup-count: 1
+          # the delay after which auto-scaled jobs will restart if a new member is added to the
+          # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
+          scale-up-delay-millis: 10000
+          # Sets whether lossless job restart is enabled for the node. With
+          # lossless restart you can restart the whole cluster without losing the
+          # jobs and their state. The feature is implemented on top of the Hot
+          # Restart feature of Hazelcast IMDG which persists the data to disk.
+          lossless-restart-enabled: false
+        edge-defaults:
+          # capacity of the concurrent SPSC queue between each two processors
+          queue-size: 1024
+          # network packet size limit in bytes, only applies to distributed edges
+          packet-size-limit: 16384
+          # receive window size multiplier, only applies to distributed edges
+          receive-window-multiplier: 3
+        metrics:
+          # whether metrics collection is enabled
+          enabled: true
+          # whether jmx mbean metrics collection is enabled
+          jmx-enabled: true
+          # the number of seconds the metrics will be retained on the instance
+          retention-seconds: 120
+          # the metrics collection interval in seconds
+          collection-interval-seconds: 5
+          # whether metrics should be collected for data structures. Metrics
+          # collection can have some overhead if there is a large number of data
+          # structures
+          metrics-for-data-structures: false
       
 # nodeSelector is an array of Hazelcast Node labels for POD assignments
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
@@ -170,6 +156,16 @@ securityContext:
   # fsGroup is the group ID associated with the container
   fsGroup: 1001
 
+# Allows to enable a Prometheus to scrape pods
+metrics:
+  enabled: false
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/path: "/metrics"
+
 # Hazelcast Jet Management Center application properties
 managementcenter:
   # enabled is a flag to enable Hazelcast Jet Management Center application
@@ -181,7 +177,7 @@ managementcenter:
     # repository is the Hazelcast Jet Management Center image name
     repository: "hazelcast/hazelcast-jet-management-center"
     # tag is the Hazelcast Jet Management Center image tag
-    tag: "3.0"
+    tag: "3.1"
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -208,25 +204,14 @@ managementcenter:
 
   # configurationFiles are Hazelcast Jet Client configuration files which will be used by Hazelcast Jet Management Center
   configurationFiles:
-    hazelcast-client.xml: |-
-      <?xml version="1.0" encoding="UTF-8"?>
-      <hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.10.xsd"
-                        xmlns="http://www.hazelcast.com/schema/client-config"
-                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-        <properties>
-          <property name="hazelcast.discovery.enabled">true</property>
-        </properties>
-        <network>
-          <discovery-strategies>
-            <discovery-strategy enabled="true" class="com.hazelcast.kubernetes.HazelcastKubernetesDiscoveryStrategy">
-              <properties>
-                <property name="service-name">${serviceName}</property>
-                <property name="namespace">${namespace}</property>
-              </properties>
-            </discovery-strategy>
-          </discovery-strategies>
-        </network>
-      </hazelcast-client>
+    hazelcast-client.yaml: |-
+      hazelcast-client:
+        network:
+          kubernetes:
+            enabled: true
+            namespace: ${namespace}
+            service-name: ${serviceName}
+            resolve-not-ready-addresses: true
 
   # Configure resource requests and limits
   # ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Following improvements has been ported the charts:
- Prometheus metrics service
- YAML configuration file support
- Basic tests for cluster formation
- Apply recommended helm labels
- Fixed missing service name on stateful sets.
- Updated Hazelcast Jet version to 3.1