### PR TITLE
direct yaml support for Jet charts

### DIFF
--- a/stable/hazelcast-jet-enterprise/Chart.yaml
+++ b/stable/hazelcast-jet-enterprise/Chart.yaml
@@ -4,7 +4,7 @@ tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"
 description: Hazelcast Jet Enterprise provides critical management features for scaling in-memory event stream processing across your IT landscape, including Management Center, Security Suite, Lossless Recovery, Rolling Job upgrades, and Enterprise PaaS Deployment Environments.
 name: hazelcast-jet-enterprise
-version: 1.1.0
+version: 1.2.0
 keywords:
 - hazelcast
 - jet

--- a/stable/hazelcast-jet-enterprise/README.md
+++ b/stable/hazelcast-jet-enterprise/README.md
@@ -10,7 +10,7 @@ about the architecture, road-map and use cases.
 ## Quick Start
 
 ```bash
-$ helm repo add hazelcast https://hazelcast.github.io/charts/ 
+$ helm repo add hazelcast https://hazelcast.github.io/charts/
 $ helm repo update
 $ helm install hazelcast/hazelcast-jet-enterprise
 ```
@@ -60,7 +60,8 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `jet.licenseKeySecretName`                 | Kubernetes Secret Name, where Hazelcast Jet Enterprise Key is stored (can be used instead of licenseKey)       | `nil`                                                |
 | `jet.rest`                                 | Enable REST endpoints for Hazelcast Jet member                                                                 | `true`                                               |
 | `jet.javaOpts`                             | Additional JAVA_OPTS properties for Hazelcast Jet member                                                       | `nil`                                                |
-| `jet.configurationFiles`                   | Hazelcast configuration files                                                                                  | `{DEFAULT_HAZELCAST_XML}`                            |
+| `jet.yaml.hazelcast-jet` and `jet.yaml.hazelcast`                   | Hazelcast Jet and IMDG YAML configurations (`hazelcast-jet.yaml` and `hazelcast.yaml` embedded into `values.yaml`)                                                                                | `{DEFAULT_JET_YAML}` and `{DEFAULT_HAZELCAST_YAML}`                  |
+| `jet.configurationFiles`                   | Hazelcast configuration files                                                                                  | `nil`                           |
 | `nodeSelector`                             | Hazelcast Node labels for pod assignment                                                                       | `nil`                                                |
 | `gracefulShutdown.enabled`                 | Turn on and off Graceful Shutdown                                                                              | `true`                                               |
 | `gracefulShutdown.maxWaitSeconds`          | Maximum time to wait for the Hazelcast Jet POD to shut down                                                    | `600`                                                |
@@ -134,57 +135,40 @@ $ helm install --name my-release -f values.yaml hazelcast/hazelcast-jet-enterpri
 
 ## Custom Hazelcast IMDG and Jet configuration
 
-Custom Hazelcast IMDG and Hazelcast Jet configuration can be specified inside `values.yaml`, as the `jet.configurationFiles.hazelcast.yaml` and `jet.configurationFiles.hazelcast-jet.yaml` properties.
+Custom Hazelcast IMDG and Hazelcast Jet configuration can be specified inside `values.yaml`, as the `jet.yaml.hazelcast` and `jet.yaml.hazelcast-jet` properties.
 
 ```yaml
 jet:
-  configurationFiles:
-    hazelcast.yaml: |-
-      hazelcast:
-        license-key: Your Hazelcast Jet Enterprise License Key
-        network:
-          join:
-            multicast:
-              enabled: false
-            kubernetes:
-              enabled: true
-              namespace: ${namespace}
-              service-name: ${serviceName}
-              resolve-not-ready-addresses: true
-    hazelcast-jet.yaml: |-
-      hazelcast-jet:
-        instance:
-          # period between flow control packets in milliseconds
-          flow-control-period: 100
-          # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
-          backup-count: 1
-          # the delay after which auto-scaled jobs will restart if a new member is added to the
-          # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
-          scale-up-delay-millis: 10000
-          # Sets whether lossless job restart is enabled for the node. With
-          # lossless restart you can restart the whole cluster without losing the
-          # jobs and their state. The feature is implemented on top of the Hot
-          # Restart feature of Hazelcast IMDG which persists the data to disk.
-          lossless-restart-enabled: false
-        edge-defaults:
-          # capacity of the concurrent SPSC queue between each two processors
-          queue-size: 1024
-          # network packet size limit in bytes, only applies to distributed edges
-          packet-size-limit: 16384
-          # receive window size multiplier, only applies to distributed edges
-          receive-window-multiplier: 3
-        metrics:
-          # whether metrics collection is enabled
-          enabled: true
-          # whether jmx mbean metrics collection is enabled
-          jmx-enabled: true
-          # the number of seconds the metrics will be retained on the instance
-          retention-seconds: 120
-          # the metrics collection interval in seconds
-          collection-interval-seconds: 5
-          # whether metrics should be collected for data structures. Metrics
-          # collection can have some overhead if there is a large number of data
-          # structures
-          metrics-for-data-structures: false
-      
+  yaml:
+    hazelcast:
+      network:
+        join:
+          multicast:
+            enabled: false
+          kubernetes:
+            enabled: true
+            service-name: ${serviceName}
+            namespace: ${namespace}
+            resolve-not-ready-addresses: true
+      management-center:
+        enabled: ${hazelcast.mancenter.enabled}
+        url: ${hazelcast.mancenter.url}
+    hazelcast-jet:
+      instance:
+        flow-control-period: 100
+        backup-count: 1
+        scale-up-delay-millis: 10000
+        lossless-restart-enabled: false
+      edge-defaults:
+        queue-size: 1024
+        packet-size-limit: 16384
+        receive-window-multiplier: 3
+      metrics:
+        enabled: true
+        jmx-enabled: true
+        retention-seconds: 120
+        collection-interval-seconds: 5
+        metrics-for-data-structures: false
+
+
 ```

--- a/stable/hazelcast-jet-enterprise/README.md
+++ b/stable/hazelcast-jet-enterprise/README.md
@@ -172,3 +172,11 @@ jet:
 
 
 ```
+
+Alternatively, above parameters can be modified directly via `helm` commands. For example,
+
+```bash
+$ helm install --name my-jet-release \
+  --set jet.yaml.hazelcast-jet.instance.backup-count=2,jet.yaml.hazelcast.network.kubernetes.service-name=jet-service \
+    hazelcast/hazelcast-jet
+```

--- a/stable/hazelcast-jet-enterprise/templates/config.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jet.configurationFiles }}
+{{- if or .Values.jet.configurationFiles .Values.jet.yaml }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,4 +13,11 @@ data:
   {{ $key }}: |-
 {{ $val | indent 4}}
 {{- end }}
+  hazelcast.yaml: |-
+    hazelcast:
+{{ toYaml .Values.jet.yaml.hazelcast | indent 5 }}
+{{ $jetYaml := index .Values "jet" "yaml" "hazelcast-jet"}}
+  hazelcast-jet.yaml: |-
+    hazelcast-jet:
+{{ toYaml $jetYaml | indent 5 }}
 {{- end -}}

--- a/stable/hazelcast-jet-enterprise/templates/management-center-config.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/management-center-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.managementcenter.configurationFiles }}
+{{- if or .Values.managementcenter.configurationFiles .Values.managementcenter.yaml}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,4 +13,6 @@ data:
   {{ $key }}: |-
 {{ $val | indent 4}}
 {{- end }}
+  hazelcast-client.yaml: |-
+{{ toYaml .Values.managementcenter.yaml | indent 4 }}
 {{- end -}}

--- a/stable/hazelcast-jet-enterprise/values.yaml
+++ b/stable/hazelcast-jet-enterprise/values.yaml
@@ -27,59 +27,64 @@ jet:
   # licenseKey is the Hazelcast Jet Enterprise License Key (always required to run Hazelcast Jet Enterprise)
   licenseKey:
   # licenseKeySecretName is the name of the secret where the Hazelcast Jet Enterprise License Key is stored (can be used instead of licenseKey)
-  # licenseKeySecretName: 
+  # licenseKeySecretName:
   # rest is a flag used to enable REST endpoints for Hazelcast Jet member
   rest: true
   # javaOpts are additional JAVA_OPTS properties for Hazelcast Jet member
   javaOpts:
-  # configurationFiles are Hazelcast Jet configuration files
-  configurationFiles:
-    hazelcast.yaml: |-
-      hazelcast:
-        network:
-          join:
-            multicast:
-              enabled: false
-            kubernetes:
-              enabled: true
-              namespace: ${namespace}
-              service-name: ${serviceName}
-    hazelcast-jet.yaml: |-
-      hazelcast-jet:
-        instance:
-          # period between flow control packets in milliseconds
-          flow-control-period: 100
-          # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
-          backup-count: 1
-          # the delay after which auto-scaled jobs will restart if a new member is added to the
-          # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
-          scale-up-delay-millis: 10000
-          # Sets whether lossless job restart is enabled for the node. With
-          # lossless restart you can restart the whole cluster without losing the
-          # jobs and their state. The feature is implemented on top of the Hot
-          # Restart feature of Hazelcast IMDG which persists the data to disk.
-          lossless-restart-enabled: false
-        edge-defaults:
-          # capacity of the concurrent SPSC queue between each two processors
-          queue-size: 1024
-          # network packet size limit in bytes, only applies to distributed edges
-          packet-size-limit: 16384
-          # receive window size multiplier, only applies to distributed edges
-          receive-window-multiplier: 3
-        metrics:
-          # whether metrics collection is enabled
-          enabled: true
-          # whether jmx mbean metrics collection is enabled
-          jmx-enabled: true
-          # the number of seconds the metrics will be retained on the instance
-          retention-seconds: 120
-          # the metrics collection interval in seconds
-          collection-interval-seconds: 5
-          # whether metrics should be collected for data structures. Metrics
-          # collection can have some overhead if there is a large number of data
-          # structures
-          metrics-for-data-structures: false
-      
+  # Jet and Hazelcast IMDG YAML configuration files
+  yaml:
+    hazelcast:
+      network:
+        join:
+          multicast:
+            enabled: false
+          kubernetes:
+            enabled: true
+            service-name: ${serviceName}
+            namespace: ${namespace}
+            resolve-not-ready-addresses: true
+      management-center:
+        enabled: ${hazelcast.mancenter.enabled}
+        url: ${hazelcast.mancenter.url}
+    hazelcast-jet:
+      instance:
+        # period between flow control packets in milliseconds
+        flow-control-period: 100
+        # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
+        backup-count: 1
+        # the delay after which auto-scaled jobs will restart if a new member is added to the
+        # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
+        scale-up-delay-millis: 10000
+        # Sets whether lossless job restart is enabled for the node. With
+        # lossless restart you can restart the whole cluster without losing the
+        # jobs and their state. The feature is implemented on top of the Hot
+        # Restart feature of Hazelcast IMDG which persists the data to disk.
+        lossless-restart-enabled: false
+      edge-defaults:
+        # capacity of the concurrent SPSC queue between each two processors
+        queue-size: 1024
+        # network packet size limit in bytes, only applies to distributed edges
+        packet-size-limit: 16384
+        # receive window size multiplier, only applies to distributed edges
+        receive-window-multiplier: 3
+      metrics:
+        # whether metrics collection is enabled
+        enabled: true
+        # whether jmx mbean metrics collection is enabled
+        jmx-enabled: true
+        # the number of seconds the metrics will be retained on the instance
+        retention-seconds: 120
+        # the metrics collection interval in seconds
+        collection-interval-seconds: 5
+        # whether metrics should be collected for data structures. Metrics
+        # collection can have some overhead if there is a large number of data
+        # structures
+        metrics-for-data-structures: false
+
+  # configurationFiles are any additional Hazelcast Jet configuration files
+  # configurationFiles:
+
 # nodeSelector is an array of Hazelcast Node labels for POD assignments
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
@@ -199,21 +204,24 @@ managementcenter:
   # if not provided, it can be filled in the Management Center web interface
   licenseKey:
   # licenseKeySecretName is the name of the secret where the Hazelcast Jet Management Center License Key is stored (can be used instead of licenseKey)
-  # licenseKeySecretName: 
+  # licenseKeySecretName:
 
   # nodeSelector is an array of Hazelcast Jet Management Center Node labels for POD assignments
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   nodeSelector: {}
 
-  # configurationFiles are Hazelcast Jet Client configuration files which will be used by Hazelcast Jet Management Center
-  configurationFiles:
-    hazelcast-client.yaml: |-
-      hazelcast-client:
-        network:
-          kubernetes:
-            enabled: true
-            namespace: ${namespace}
-            service-name: ${serviceName}
+  # Jet Client configuration YAML file which will be used by Hazelcast Jet Management Center
+  yaml:
+    hazelcast-client:
+      network:
+        kubernetes:
+          enabled: true
+          namespace: ${namespace}
+          service-name: ${serviceName}
+          resolve-not-ready-addresses: true
+
+  # configurationFiles are any additional Hazelcast Jet Client configuration files
+  # configurationFiles:
 
   # Configure resource requests and limits
   # ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/hazelcast-jet/Chart.yaml
+++ b/stable/hazelcast-jet/Chart.yaml
@@ -4,7 +4,7 @@ tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"
 description: Hazelcast Jet is an application embeddable, distributed computing engine built on top of Hazelcast In-Memory Data Grid (IMDG). With Hazelcast IMDG providing storage functionality, Hazelcast Jet performs parallel execution to enable data-intensive applications to operate in near real-time.
 name: hazelcast-jet
-version: 1.1.0
+version: 1.2.0
 keywords:
 - hazelcast
 - jet

--- a/stable/hazelcast-jet/README.md
+++ b/stable/hazelcast-jet/README.md
@@ -171,3 +171,11 @@ jet:
         metrics-for-data-structures: false
 
 ```
+
+Alternatively, above parameters can be modified directly via `helm` commands. For example,
+
+```bash
+$ helm install --name my-jet-release \
+  --set jet.yaml.hazelcast-jet.instance.backup-count=2,jet.yaml.hazelcast.network.kubernetes.service-name=jet-service \
+    hazelcast/hazelcast-jet
+```

--- a/stable/hazelcast-jet/README.md
+++ b/stable/hazelcast-jet/README.md
@@ -12,7 +12,7 @@ about the architecture and use cases.
 ## Quick Start
 
 ```bash
-$ helm repo add hazelcast https://hazelcast.github.io/charts/ 
+$ helm repo add hazelcast https://hazelcast.github.io/charts/
 $ helm repo update
 $ helm install hazelcast/hazelcast-jet
 ```
@@ -60,7 +60,8 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `cluster.memberCount`                      | Number of Hazelcast Jet members                                                                                | 2                                                    |
 | `jet.rest`                                 | Enable REST endpoints for Hazelcast Jet member                                                                 | `true`                                               |
 | `jet.javaOpts`                             | Additional JAVA_OPTS properties for Hazelcast Jet member                                                       | `nil`                                                |
-| `jet.configurationFiles`                   | Hazelcast configuration files                                                                                  | `{DEFAULT_HAZELCAST_XML}`                            |
+| `jet.yaml.hazelcast-jet` and `jet.yaml.hazelcast`                   | Hazelcast Jet and IMDG YAML configurations (`hazelcast-jet.yaml` and `hazelcast.yaml` embedded into `values.yaml`)                                                                                | `{DEFAULT_JET_YAML}` and `{DEFAULT_HAZELCAST_YAML}`                  |
+| `jet.configurationFiles`                   | Hazelcast configuration files                                                                                  | `nil`                           |
 | `nodeSelector`                             | Hazelcast Node labels for pod assignment                                                                       | `nil`                                                |
 | `gracefulShutdown.enabled`                 | Turn on and off Graceful Shutdown                                                                              | `true`                                               |
 | `gracefulShutdown.maxWaitSeconds`          | Maximum time to wait for the Hazelcast Jet POD to shut down                                                    | `600`                                                |
@@ -134,56 +135,39 @@ $ helm install --name my-release -f values.yaml hazelcast/hazelcast-jet
 
 ## Custom Hazelcast IMDG and Jet configuration
 
-Custom Hazelcast IMDG and Hazelcast Jet configuration can be specified inside `values.yaml`, as the `jet.configurationFiles.hazelcast.yaml` and `jet.configurationFiles.hazelcast-jet.yaml` properties.
+Custom Hazelcast IMDG and Hazelcast Jet configuration can be specified inside `values.yaml`, as the `jet.yaml.hazelcast` and `jet.yaml.hazelcast-jet` properties.
 
 ```yaml
 jet:
-  configurationFiles:
-    hazelcast.yaml: |-
-      hazelcast:
-        network:
-          join:
-            multicast:
-              enabled: false
-            kubernetes:
-              enabled: true
-              namespace: ${namespace}
-              service-name: ${serviceName}
-              resolve-not-ready-addresses: true
-    hazelcast-jet.yaml: |-
-      hazelcast-jet:
-        instance:
-          # period between flow control packets in milliseconds
-          flow-control-period: 100
-          # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
-          backup-count: 1
-          # the delay after which auto-scaled jobs will restart if a new member is added to the
-          # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
-          scale-up-delay-millis: 10000
-          # Sets whether lossless job restart is enabled for the node. With
-          # lossless restart you can restart the whole cluster without losing the
-          # jobs and their state. The feature is implemented on top of the Hot
-          # Restart feature of Hazelcast IMDG which persists the data to disk.
-          lossless-restart-enabled: false
-        edge-defaults:
-          # capacity of the concurrent SPSC queue between each two processors
-          queue-size: 1024
-          # network packet size limit in bytes, only applies to distributed edges
-          packet-size-limit: 16384
-          # receive window size multiplier, only applies to distributed edges
-          receive-window-multiplier: 3
-        metrics:
-          # whether metrics collection is enabled
-          enabled: true
-          # whether jmx mbean metrics collection is enabled
-          jmx-enabled: true
-          # the number of seconds the metrics will be retained on the instance
-          retention-seconds: 120
-          # the metrics collection interval in seconds
-          collection-interval-seconds: 5
-          # whether metrics should be collected for data structures. Metrics
-          # collection can have some overhead if there is a large number of data
-          # structures
-          metrics-for-data-structures: false
-      
+  yaml:
+    hazelcast:
+      network:
+        join:
+          multicast:
+            enabled: false
+          kubernetes:
+            enabled: true
+            service-name: ${serviceName}
+            namespace: ${namespace}
+            resolve-not-ready-addresses: true
+      management-center:
+        enabled: ${hazelcast.mancenter.enabled}
+        url: ${hazelcast.mancenter.url}
+    hazelcast-jet:
+      instance:
+        flow-control-period: 100
+        backup-count: 1
+        scale-up-delay-millis: 10000
+        lossless-restart-enabled: false
+      edge-defaults:
+        queue-size: 1024
+        packet-size-limit: 16384
+        receive-window-multiplier: 3
+      metrics:
+        enabled: true
+        jmx-enabled: true
+        retention-seconds: 120
+        collection-interval-seconds: 5
+        metrics-for-data-structures: false
+
 ```

--- a/stable/hazelcast-jet/templates/config.yaml
+++ b/stable/hazelcast-jet/templates/config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.jet.configurationFiles }}
+{{- if or .Values.jet.configurationFiles .Values.jet.yaml }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,4 +13,11 @@ data:
   {{ $key }}: |-
 {{ $val | indent 4}}
 {{- end }}
+  hazelcast.yaml: |-
+    hazelcast:
+{{ toYaml .Values.jet.yaml.hazelcast | indent 5 }}
+{{ $jetYaml := index .Values "jet" "yaml" "hazelcast-jet"}}
+  hazelcast-jet.yaml: |-
+    hazelcast-jet:
+{{ toYaml $jetYaml | indent 5 }}
 {{- end -}}

--- a/stable/hazelcast-jet/templates/management-center-config.yaml
+++ b/stable/hazelcast-jet/templates/management-center-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.managementcenter.configurationFiles }}
+{{- if or .Values.managementcenter.configurationFiles .Values.managementcenter.yaml}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,4 +13,6 @@ data:
   {{ $key }}: |-
 {{ $val | indent 4}}
 {{- end }}
+  hazelcast-client.yaml: |-
+{{ toYaml .Values.managementcenter.yaml | indent 4 }}
 {{- end -}}

--- a/stable/hazelcast-jet/templates/statefulset.yaml
+++ b/stable/hazelcast-jet/templates/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
         {{- if .Values.metrics.enabled }}
         - name: metrics
           containerPort: {{ .Values.metrics.service.port }}
-        {{- end }}          
+        {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/stable/hazelcast-jet/values.yaml
+++ b/stable/hazelcast-jet/values.yaml
@@ -28,55 +28,59 @@ jet:
   rest: true
   # javaOpts are additional JAVA_OPTS properties for Hazelcast Jet member
   javaOpts:
-  # configurationFiles are Hazelcast Jet configuration files
-  configurationFiles:
-    hazelcast.yaml: |-
-      hazelcast:
-        network:
-          join:
-            multicast:
-              enabled: false
-            kubernetes:
-              enabled: true
-              namespace: ${namespace}
-              service-name: ${serviceName}
-              resolve-not-ready-addresses: true
-    hazelcast-jet.yaml: |-
-      hazelcast-jet:
-        instance:
-          # period between flow control packets in milliseconds
-          flow-control-period: 100
-          # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
-          backup-count: 1
-          # the delay after which auto-scaled jobs will restart if a new member is added to the
-          # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
-          scale-up-delay-millis: 10000
-          # Sets whether lossless job restart is enabled for the node. With
-          # lossless restart you can restart the whole cluster without losing the
-          # jobs and their state. The feature is implemented on top of the Hot
-          # Restart feature of Hazelcast IMDG which persists the data to disk.
-          lossless-restart-enabled: false
-        edge-defaults:
-          # capacity of the concurrent SPSC queue between each two processors
-          queue-size: 1024
-          # network packet size limit in bytes, only applies to distributed edges
-          packet-size-limit: 16384
-          # receive window size multiplier, only applies to distributed edges
-          receive-window-multiplier: 3
-        metrics:
-          # whether metrics collection is enabled
-          enabled: true
-          # whether jmx mbean metrics collection is enabled
-          jmx-enabled: true
-          # the number of seconds the metrics will be retained on the instance
-          retention-seconds: 120
-          # the metrics collection interval in seconds
-          collection-interval-seconds: 5
-          # whether metrics should be collected for data structures. Metrics
-          # collection can have some overhead if there is a large number of data
-          # structures
-          metrics-for-data-structures: false
-      
+  # Jet and Hazelcast IMDG YAML configuration files
+  yaml:
+    hazelcast:
+      network:
+        join:
+          multicast:
+            enabled: false
+          kubernetes:
+            enabled: true
+            service-name: ${serviceName}
+            namespace: ${namespace}
+            resolve-not-ready-addresses: true
+      management-center:
+        enabled: ${hazelcast.mancenter.enabled}
+        url: ${hazelcast.mancenter.url}
+    hazelcast-jet:
+      instance:
+        # period between flow control packets in milliseconds
+        flow-control-period: 100
+        # number of backup copies to configure for Hazelcast IMaps used internally in a Jet job
+        backup-count: 1
+        # the delay after which auto-scaled jobs will restart if a new member is added to the
+        # cluster. The default is 10 seconds. Has no effect on jobs with auto scaling disabled
+        scale-up-delay-millis: 10000
+        # Sets whether lossless job restart is enabled for the node. With
+        # lossless restart you can restart the whole cluster without losing the
+        # jobs and their state. The feature is implemented on top of the Hot
+        # Restart feature of Hazelcast IMDG which persists the data to disk.
+        lossless-restart-enabled: false
+      edge-defaults:
+        # capacity of the concurrent SPSC queue between each two processors
+        queue-size: 1024
+        # network packet size limit in bytes, only applies to distributed edges
+        packet-size-limit: 16384
+        # receive window size multiplier, only applies to distributed edges
+        receive-window-multiplier: 3
+      metrics:
+        # whether metrics collection is enabled
+        enabled: true
+        # whether jmx mbean metrics collection is enabled
+        jmx-enabled: true
+        # the number of seconds the metrics will be retained on the instance
+        retention-seconds: 120
+        # the metrics collection interval in seconds
+        collection-interval-seconds: 5
+        # whether metrics should be collected for data structures. Metrics
+        # collection can have some overhead if there is a large number of data
+        # structures
+        metrics-for-data-structures: false
+
+  # configurationFiles are any additional Hazelcast Jet configuration files
+  # configurationFiles:
+
 # nodeSelector is an array of Hazelcast Node labels for POD assignments
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
@@ -202,16 +206,18 @@ managementcenter:
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   nodeSelector: {}
 
-  # configurationFiles are Hazelcast Jet Client configuration files which will be used by Hazelcast Jet Management Center
-  configurationFiles:
-    hazelcast-client.yaml: |-
-      hazelcast-client:
-        network:
-          kubernetes:
-            enabled: true
-            namespace: ${namespace}
-            service-name: ${serviceName}
-            resolve-not-ready-addresses: true
+  # Jet Client configuration YAML file which will be used by Hazelcast Jet Management Center
+  yaml:
+    hazelcast-client:
+      network:
+        kubernetes:
+          enabled: true
+          namespace: ${namespace}
+          service-name: ${serviceName}
+          resolve-not-ready-addresses: true
+
+  # configurationFiles are any additional Hazelcast Jet Client configuration files
+  # configurationFiles:
 
   # Configure resource requests and limits
   # ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
Existing version of Jet charts already support `yaml` configuration but we can not give jet/imdg config parameters via `--set`. With this enhancement, config parameters can be modified directly:

```bash
$ helm install --name my-jet-release \
  --set jet.yaml.hazelcast-jet.instance.backup-count=2,jet.yaml.hazelcast.network.kubernetes.service-name=jet-service \
    hazelcast/hazelcast-jet
```