### PR TITLE
test script for new pr-builder

### DIFF
--- a/run-test
+++ b/run-test
@@ -7,9 +7,11 @@ kubectl version
 helm version --client --tls
 
 function cleanup() {
-    helm ls --all --short --tls | xargs -L1 helm delete --purge || true
+    echo "Deleting existing Helm releases..."
+    helm ls --all --short --tls | xargs -L1 helm delete --purge --tls || true
+    echo "Uninstalling tiller form k8s cluster..."
     helm reset --tls || true
-    #remove helm test pods
+    echo "Removing Helm test pods..."
     kubectl get pods | grep Completed | awk '{print $1}' | xargs kubectl delete pod || true
 }
 
@@ -19,8 +21,10 @@ cleanup
 # kubectl create serviceaccount -n kube-system tiller
 # kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 
+echo "Initializing the Helm/Tiller..."
 helm init --service-account tiller --tiller-tls-verify --wait
 
+echo "Packaging local Helm charts..."
 for chart in ${WORKSPACE}/stable/*; do
     helm package --save=false ${chart};
 done
@@ -28,12 +32,12 @@ done
 HAZELCAST_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-[0-9].[0-9].[0-9].tgz?')
 JET_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-jet-[0-9].[0-9].[0-9].tgz?')
 
+echo "Testing Hazelcast IMDG Chart..."
 helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 --tls ${HAZELCAST_HELM_PATH}
 helm lint ${HAZELCAST_HELM_PATH}
 helm test hz-release --cleanup --tls
 
-#cleanup?
-
+echo "Testing JET Chart..."
 helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 --tls ${JET_HELM_PATH}
 helm lint ${JET_HELM_PATH}
 helm test jet-release --cleanup --tls

--- a/run-test
+++ b/run-test
@@ -18,8 +18,20 @@ function cleanup() {
 trap cleanup EXIT ERR INT TERM
 cleanup
 
-# kubectl create serviceaccount -n kube-system tiller
-# kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+TILLER_SA="tiller"
+if kubectl get serviceaccounts -n kube-system | grep "${TILLER_SA}" | tail -n 1; then
+    echo "tiller serviceaccount is already created."
+    TILLER_BOUND_ROLE=$(kubectl get -n kube-system clusterrolebinding tiller-cluster-rule -o jsonpath='{.roleRef.name}')
+    if [ "$TILLER_BOUND_ROLE" != "cluster-admin" ]; then
+        kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:${TILLER_SA}
+        echo "cluster-admin role is bound to existing tiller serviceaccount."
+    fi
+else
+    echo "tiller serviceaccount is not found. Creating..."
+    kubectl create serviceaccount -n kube-system ${TILLER_SA}
+    kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:${TILLER_SA}
+    echo "tiller serviceaccount created and cluster-admin role is bound to it."
+fi
 
 echo "Initializing the Helm/Tiller..."
 helm init --service-account tiller --wait

--- a/run-test
+++ b/run-test
@@ -19,8 +19,7 @@ cleanup
 # kubectl create serviceaccount -n kube-system tiller
 # kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 
-helm init --service-account tiller
-kubectl -n kube-system wait --for=condition=Ready pod -l name=tiller --timeout=60s
+helm init --service-account tiller --wait
 
 for chart in ${WORKSPACE}/stable/*; do
     helm package --save=false ${chart};
@@ -29,14 +28,14 @@ done
 HAZELCAST_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-[0-9].[0-9].[0-9].tgz?')
 JET_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-jet-[0-9].[0-9].[0-9].tgz?')
 
-helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 ${HAZELCAST_HELM_PATH}
+helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 --tiller-connection-timeout=600 ${HAZELCAST_HELM_PATH}
 helm lint ${HAZELCAST_HELM_PATH}
-helm test hz-release
+helm test --tiller-connection-timeout=600 hz-release
 
 #cleanup?
 
-helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 ${JET_HELM_PATH}
+helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 --tiller-connection-timeout=600 ${JET_HELM_PATH}
 helm lint ${JET_HELM_PATH}
-helm test jet-release
+helm test --tiller-connection-timeout=600 jet-release
 
 

--- a/run-test
+++ b/run-test
@@ -4,13 +4,13 @@ set -e
 set -o pipefail
 
 kubectl version
-helm version --client --tls
+helm version --client
 
 function cleanup() {
     echo "Deleting existing Helm releases..."
-    helm ls --all --short --tls | xargs -L1 helm delete --purge --tls || true
+    helm ls --all --short | xargs -L1 helm delete --purge || true
     echo "Uninstalling tiller form k8s cluster..."
-    helm reset --tls || true
+    helm reset || true
     echo "Removing Helm test pods..."
     kubectl get pods | grep Completed | awk '{print $1}' | xargs kubectl delete pod || true
 }
@@ -22,7 +22,7 @@ cleanup
 # kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 
 echo "Initializing the Helm/Tiller..."
-helm init --service-account tiller --tiller-tls-verify --wait
+helm init --service-account tiller --wait
 
 echo "Packaging local Helm charts..."
 for chart in ${WORKSPACE}/stable/*; do
@@ -33,13 +33,13 @@ HAZELCAST_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-[0-9].[0-9].[0-9].tg
 JET_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-jet-[0-9].[0-9].[0-9].tgz?')
 
 echo "Testing Hazelcast IMDG Chart..."
-helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 --tls ${HAZELCAST_HELM_PATH}
+helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 ${HAZELCAST_HELM_PATH}
 helm lint ${HAZELCAST_HELM_PATH}
-helm test hz-release --cleanup --tls
+helm test hz-release --debug --cleanup
 
 echo "Testing JET Chart..."
-helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 --tls ${JET_HELM_PATH}
+helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 ${JET_HELM_PATH}
 helm lint ${JET_HELM_PATH}
-helm test jet-release --cleanup --tls
+helm test jet-release --debug --cleanup
 
 

--- a/run-test
+++ b/run-test
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+kubectl version
+helm version --client
+
+function cleanup() {
+    helm ls --all --short | xargs -L1 helm delete --purge || true
+    helm reset || true
+    #remove helm test pods
+    kubectl get pods | grep Completed | awk '{print $1}' | xargs kubectl delete pod || true
+}
+
+trap cleanup EXIT ERR INT TERM
+cleanup
+
+# kubectl create serviceaccount -n kube-system tiller
+# kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+
+helm init --service-account tiller
+kubectl -n kube-system wait --for=condition=Ready pod -l name=tiller --timeout=60s
+
+for chart in ${WORKSPACE}/stable/*; do
+    helm package --save=false ${chart};
+done
+
+HAZELCAST_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-[0-9].[0-9].[0-9].tgz?')
+JET_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-jet-[0-9].[0-9].[0-9].tgz?')
+
+helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 ${HAZELCAST_HELM_PATH}
+helm lint ${HAZELCAST_HELM_PATH}
+helm test hz-release
+
+#cleanup?
+
+helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 ${JET_HELM_PATH}
+helm lint ${JET_HELM_PATH}
+helm test jet-release
+
+

--- a/run-test
+++ b/run-test
@@ -4,11 +4,11 @@ set -e
 set -o pipefail
 
 kubectl version
-helm version --client
+helm version --client --tls
 
 function cleanup() {
-    helm ls --all --short | xargs -L1 helm delete --purge || true
-    helm reset || true
+    helm ls --all --short --tls | xargs -L1 helm delete --purge || true
+    helm reset --tls || true
     #remove helm test pods
     kubectl get pods | grep Completed | awk '{print $1}' | xargs kubectl delete pod || true
 }
@@ -19,7 +19,7 @@ cleanup
 # kubectl create serviceaccount -n kube-system tiller
 # kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
 
-helm init --service-account tiller --wait
+helm init --service-account tiller --tiller-tls-verify --wait
 
 for chart in ${WORKSPACE}/stable/*; do
     helm package --save=false ${chart};
@@ -28,14 +28,14 @@ done
 HAZELCAST_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-[0-9].[0-9].[0-9].tgz?')
 JET_HELM_PATH=$(find ${WORKSPACE} -regex '.*hazelcast-jet-[0-9].[0-9].[0-9].tgz?')
 
-helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 --tiller-connection-timeout=600 ${HAZELCAST_HELM_PATH}
+helm install --debug --name hz-release --set nodeSelector.pool=standard,hazelcast.yaml.hazelcast.network.kubernetes.service-name=hz-helm-service,mancenter.nodeSelector.pool=standard --wait --timeout=360 --tls ${HAZELCAST_HELM_PATH}
 helm lint ${HAZELCAST_HELM_PATH}
-helm test --tiller-connection-timeout=600 hz-release
+helm test hz-release --cleanup --tls
 
 #cleanup?
 
-helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 --tiller-connection-timeout=600 ${JET_HELM_PATH}
+helm install --debug --name jet-release --set nodeSelector.pool=standard,jet.yaml.hazelcast.network.kubernetes.service-name=jet-helm-service,managementcenter.nodeSelector.pool=standard --wait --timeout=360 --tls ${JET_HELM_PATH}
 helm lint ${JET_HELM_PATH}
-helm test --tiller-connection-timeout=600 jet-release
+helm test jet-release --cleanup --tls
 
 

--- a/stable/hazelcast-jet/Chart.yaml
+++ b/stable/hazelcast-jet/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "3.1"
+appVersion: "3.2"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"
 description: Hazelcast Jet is an application embeddable, distributed computing engine built on top of Hazelcast In-Memory Data Grid (IMDG). With Hazelcast IMDG providing storage functionality, Hazelcast Jet performs parallel execution to enable data-intensive applications to operate in near real-time.

--- a/stable/hazelcast-jet/templates/tests/test-hazelcast-jet.yaml
+++ b/stable/hazelcast-jet/templates/tests/test-hazelcast-jet.yaml
@@ -19,6 +19,10 @@ spec:
   securityContext:
     runAsNonRoot: true
     runAsUser: 1001
+  {{- if .Values.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 4 }}
+  {{- end }}
   containers:
   - name: "{{ template "hazelcast-jet.fullname" . }}-test"
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/hazelcast-jet/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-jet/templates/tests/test-management-center.yaml
@@ -19,6 +19,10 @@ spec:
   securityContext:
     runAsNonRoot: true
     runAsUser: 1001
+  {{- if .Values.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 4 }}
+  {{- end }}
   containers:
   - name: "{{ template "hazelcast-jet-management-center.fullname" . }}-test"
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast
-version: 1.9.3
+version: 1.9.4
 appVersion: "3.12.2"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast/templates/tests/test-hazelcast.yaml
@@ -19,6 +19,10 @@ spec:
   securityContext:
     runAsNonRoot: true
     runAsUser: 1001
+  {{- if .Values.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 4 }}
+  {{- end }}
   containers:
   - name: "{{ template "hazelcast.fullname" . }}-test"
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/stable/hazelcast/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast/templates/tests/test-management-center.yaml
@@ -19,6 +19,10 @@ spec:
   securityContext:
     runAsNonRoot: true
     runAsUser: 1001
+  {{- if .Values.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 4 }}
+  {{- end }}
   containers:
   - name: "{{ template "mancenter.fullname" . }}-test"
     image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
With this PR;

-  added new test script which utilize tests folders unders `stable/hazelcast` and `stable/hazelcast-jet` charts. Our new[ helm-charts-os-pr-builder](http://jenkins.hazelcast.com/view/Plugins/job/helm-charts-os-pr-builder/) jenkins job runs this script.
-  enabled `nodeSelector` parameter for above test templates

If you make changes at enterprise helm charts, unfortunately `helm-charts-os-pr-builder` job will be triggered as well. To prevent it, we need to upgrade `ghpr` plugin at jenkins to `1.3.8` or higher:
https://github.com/jenkinsci/ghprb-plugin/pull/293