### PR TITLE
Fixed mancenter service port name

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast-enterprise
-version: 1.10.2
+version: 1.10.3
 appVersion: "3.12.2"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
@@ -32,13 +32,13 @@ spec:
         paths:
           - backend:
               serviceName: {{ $serviceName }}
-              servicePort: mancenterhttp
+              servicePort: http
   {{- end }}
   {{- else }}
   - http:
       paths:
       - backend:
           serviceName: {{ $serviceName }}
-          servicePort: mancenterhttp
+          servicePort: http
   {{- end }}
 {{- end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-service.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-service.yaml
@@ -26,9 +26,9 @@ spec:
   - protocol: TCP
     port: {{ .Values.mancenter.service.port }}
     targetPort: mancenter
-    name: mancenterhttp
+    name: http
   - protocol: TCP
     port: {{ .Values.mancenter.service.httpsPort }}
     targetPort: mancenter
-    name: mancenterhttps
+    name: https
 {{- end }}

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,5 +1,5 @@
 name: hazelcast
-version: 1.9.2
+version: 1.9.3
 appVersion: "3.12.2"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast/templates/mancenter-ingress.yaml
@@ -32,13 +32,13 @@ spec:
         paths:
           - backend:
               serviceName: {{ $serviceName }}
-              servicePort: mancenterhttp
+              servicePort: http
   {{- end }}
   {{- else }}
   - http:
       paths:
       - backend:
           serviceName: {{ $serviceName }}
-          servicePort: mancenterhttp
+          servicePort: http
   {{- end }}
 {{- end }}

--- a/stable/hazelcast/templates/mancenter-service.yaml
+++ b/stable/hazelcast/templates/mancenter-service.yaml
@@ -25,9 +25,9 @@ spec:
   - protocol: TCP
     port: {{ .Values.mancenter.service.port }}
     targetPort: mancenter
-    name: mancenterhttp
+    name: http
   - protocol: TCP
     port: {{ .Values.mancenter.service.httpsPort }}
     targetPort: mancenter
-    name: mancenterhttps
+    name: https
 {{- end }}


### PR DESCRIPTION
With this PR;

- changed management center http port name
- changed management center https port name

those changes needed for name matching with [kubernetes aws plugin](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws) 
