### PR TITLE
fix parameter columns at imdg READMEs

### DIFF
--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -63,7 +63,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `affinity`                                 | Hazelcast Node affinity                                                                                        | `nil`                                                |
 | `tolerations`                              | Hazelcast Node tolerations                                                                                     | `nil`                                                |
 | `nodeSelector`                             | Hazelcast Node labels for pod assignment                                                                       | `nil`                                                |
-| `hostPort`                                 | Port under which Hazelcast PODs are exposed on the host machines                                               | `nil`                                                |                                         |
+| `hostPort`                                 | Port under which Hazelcast PODs are exposed on the host machines                                               | `nil`                                                |
 | `gracefulShutdown.enabled`                 | Turn on and off Graceful Shutdown                                                                              | `true`                                               |
 | `gracefulShutdown.maxWaitSeconds`          | Maximum time to wait for the Hazelcast POD to shut down                                                        | `600`                                                |
 | `livenessProbe.enabled`                    | Turn on and off liveness probe                                                                                 | `true`                                               |
@@ -137,7 +137,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | `mancenter.ingress.enabled`                | Enable ingress for the management center                             | `false`                                     |
 | `mancenter.ingress.annotations`            | Any annotations for the ingress                                      | `{}`                                        |
 | `mancenter.ingress.hosts`                  | List of hostnames for ingress, see `values.yaml` for example         | `[]`                                        |
-| `mancenter.ingress.tls`                    | List of TLS configuration for ingress, see `values.yaml` for example | `[]`                                        |  
+| `mancenter.ingress.tls`                    | List of TLS configuration for ingress, see `values.yaml` for example | `[]`                                        |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/stable/hazelcast/README.adoc
+++ b/stable/hazelcast/README.adoc
@@ -116,7 +116,7 @@ into `+values.yaml+`) |`+{DEFAULT_HAZELCAST_YAML}+`
 |`+nodeSelector+` |Hazelcast Node labels for pod assignment |`+nil+`
 
 |`+hostPort+` |Port under which Hazelcast PODs are exposed on the host machines
-|`+nil+`                                              |
+|`+nil+`
 
 |`+gracefulShutdown.enabled+` |Turn on and off Graceful Shutdown |`+true+`
 


### PR DESCRIPTION
With https://github.com/hazelcast/charts/pull/70, columns at parameters table are shifted:  

<img width="870" alt="Screen Shot 2019-10-25 at 10 21 21" src="https://user-images.githubusercontent.com/6005622/67551294-3bb91200-f711-11e9-9c34-43fc04690081.png">

