### PR TITLE
[WIP] Change networking to advanced network

### DIFF
--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -70,8 +70,8 @@ spec:
         livenessProbe:
           httpGet:
             path: /hazelcast/health/node-state
-            port: {{ if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
-            scheme: {{ if .Values.hazelcast.ssl }}HTTPS{{ else }}HTTP{{ end }}
+            port: 5702
+            scheme: HTTP
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -82,8 +82,8 @@ spec:
         readinessProbe:
           httpGet:
             path: /hazelcast/health/node-state
-            port: {{ if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
-            scheme: {{ if .Values.hazelcast.ssl }}HTTPS{{ else }}HTTP{{ end }}
+            port: 5702
+            scheme: HTTP
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -124,7 +124,7 @@ spec:
           value: "{{ .Values.metrics.service.port }}"
         {{- end }}
         - name: JAVA_OPTS
-          value: "-Dhazelcast.rest.enabled={{ .Values.hazelcast.rest }} -Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.ssl={{ .Values.hazelcast.ssl }} -Dhazelcast.hotRestart={{ .Values.hotRestart.enabled }} -Dhazelcast.mancenter.url={{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} -Dhazelcast.cluster.version.auto.upgrade.enabled={{ .Values.hazelcast.updateClusterVersionAfterRollingUpgrade }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
+          value: "-Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mancenter.enabled={{ .Values.mancenter.enabled }} -Dhazelcast.hotRestart={{ .Values.hotRestart.enabled }} -Dhazelcast.mancenter.url={{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://{{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}/hazelcast-mancenter {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} -Dhazelcast.cluster.version.auto.upgrade.enabled={{ .Values.hazelcast.updateClusterVersionAfterRollingUpgrade }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -28,10 +28,6 @@ hazelcast:
   licenseKey:
   # licenseKeySecretName is the name of the secret where the Hazelcast Enterprise License Key is stored (can be used instead of licenseKey)
   # licenseKeySecretName:
-  # rest is a flag used to enable REST endpoints for Hazelcast member
-  rest: true
-  # ssl is a flag used to enable SSL for Hazelcast
-  ssl: false
   # updateClusterVersionAfterRollingUpgrade is a flag used to automatically update the Hazelcast cluster version of the rolling upgrade procedure
   updateClusterVersionAfterRollingUpgrade: true
   # javaOpts are additional JAVA_OPTS properties for Hazelcast member
@@ -41,7 +37,8 @@ hazelcast:
   # yaml is the Hazelcast YAML configuration file
   yaml:
     hazelcast:
-      network:
+      advanced-network:
+        enabled: true
         join:
           multicast:
             enabled: false
@@ -50,8 +47,13 @@ hazelcast:
             service-name: ${serviceName}
             namespace: ${namespace}
             resolve-not-ready-addresses: true
-        ssl:
-          enabled: ${hazelcast.ssl}
+        member-server-socket-endpoint-config:
+          port: 5701
+        rest-server-socket-endpoint-config:
+          port: 5702
+          endpoint-groups:
+            HEALTH_CHECK:
+              enabled: true
       hot-restart-persistence:
         enabled: ${hazelcast.hotRestart}
         base-dir: /data/hot-restart


### PR DESCRIPTION
Changes `network` to `advanced-network` and uses always separate port for health checks.

TODO:
- Check if client can connect over the port `5701` (I'm not sure `member-server-socket-endpoint-config` implies `client-server-socket-endpoint-config`)
- Apply the same change to `hazelcast/hazelcast` chart (for the sake of consistency)
- Double check if we're fine to always make health checks over HTTP (not HTTPS). It should be fine IMO