### PR TITLE
Clean up context path

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ service/littering-pig-hazelcast-enterprise             ClusterIP      10.98.41.2
 service/littering-pig-hazelcast-enterprise-mancenter   LoadBalancer   10.104.97.143   <pending>     8080:30145/TCP   3h
 ```
 
-However, you can still reach Hazelcast Management Center with the http://MINIKUBE_IP:30145/hazelcast-mancenter for the case above. `$(minikube ip)` is the command to retrieve minikube IP address.
+However, you can still reach Hazelcast Management Center with the http://MINIKUBE_IP:30145 for the case above. `$(minikube ip)` is the command to retrieve minikube IP address.
 
 ### "cluster-admin" not found
 

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.0.1
+version: 3.0.2
 appVersion: "4.0"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast-enterprise/templates/NOTES.txt
+++ b/stable/hazelcast-enterprise/templates/NOTES.txt
@@ -42,16 +42,16 @@ To access Hazelcast Management Center:
 {{- if contains "LoadBalancer" .Values.mancenter.service.type }}
   *) Check Management Center external IP:
      $ export MANCENTER_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mancenter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  *) Open Browser at: {{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://$MANCENTER_IP:{{ .Values.mancenter.service.port }}{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}
+  *) Open Browser at: {{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://$MANCENTER_IP:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}
 {{- else if contains "ClusterIP" .Values.mancenter.service.type }}
   *) Forward port from POD:
      $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast.name" . }},role=mancenter" -o jsonpath="{.items[0].metadata.name}")
      $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 8080:8080
-  *) Open Browser at: {{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://127.0.0.1:8080{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}
+  *) Open Browser at: {{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://127.0.0.1:8080{{ .Values.mancenter.contextPath }}
 {{- else if contains "NodePort" .Values.mancenter.service.type }}
   *) Check Node IP and Port:
      $ export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
      $ export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mancenter.fullname" . }})
-  *) Open Browser at: {{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://$NODE_IP:$NODE_PORT{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}
+  *) Open Browser at: {{ if .Values.mancenter.ssl }}https{{ else }}http{{ end }}://$NODE_IP:$NODE_PORT{{ .Values.mancenter.contextPath }}
 {{- end }}
 {{- end }}

--- a/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
@@ -28,7 +28,7 @@ spec:
     - |
       set -ex
       # Get the HTTP Response Code of the Health Check
-      HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}/health)
+      HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/health)
       # Test the currect number of Hazelcast members
       test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
     securityContext:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 3.0.1
+version: 3.0.2
 appVersion: "4.0"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast/templates/NOTES.txt
+++ b/stable/hazelcast/templates/NOTES.txt
@@ -42,16 +42,16 @@ To access Hazelcast Management Center:
 {{- if contains "LoadBalancer" .Values.mancenter.service.type }}
   *) Check Management Center external IP:
      $ export MANCENTER_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "mancenter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  *) Open Browser at: http://$MANCENTER_IP:{{ .Values.mancenter.service.port }}{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}
+  *) Open Browser at: http://$MANCENTER_IP:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}
 {{- else if contains "ClusterIP" .Values.mancenter.service.type }}
   *) Forward port from POD:
      $ export POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ template "hazelcast.name" . }},role=mancenter" -o jsonpath="{.items[0].metadata.name}")
      $ kubectl port-forward --namespace {{ .Release.Namespace }} $POD 8080:8080
-  *) Open Browser at: http://127.0.0.1:8080{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}
+  *) Open Browser at: http://127.0.0.1:8080{{ .Values.mancenter.contextPath }}
 {{- else if contains "NodePort" .Values.mancenter.service.type }}
   *) Check Node IP and Port:
      $ export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
      $ export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "mancenter.fullname" . }})
-  *) Open Browser at: http://$NODE_IP:$NODE_PORT{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}
+  *) Open Browser at: http://$NODE_IP:$NODE_PORT{{ .Values.mancenter.contextPath }}
 {{- end }}
 {{- end }}

--- a/stable/hazelcast/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast/templates/tests/test-management-center.yaml
@@ -32,7 +32,7 @@ spec:
     - |
       set -ex
       # Get the HTTP Response Code of the Health Check
-      HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{- if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{- else }}/hazelcast-mancenter{{- end }}/health)
+      HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/health)
       # Test the currect number of Hazelcast members
       test ${HEALTH_CHECK_HTTP_RESPONSE_CODE} -eq 200
     securityContext:


### PR DESCRIPTION
From MC `4.0`, the context path `/hazelcast-mancenter` is not needed. This PR is to clean up this from the whole Helm Chart.