### PR TITLE
adds prometheus port on service annotations

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.0.2
+version: 3.0.3
 appVersion: "4.0"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -218,6 +218,7 @@ metrics:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/path: "/metrics"
+      prometheus.io/port: "8080"
 
 # secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
 # secretsMountName:

--- a/stable/hazelcast-jet-enterprise/Chart.yaml
+++ b/stable/hazelcast-jet-enterprise/Chart.yaml
@@ -4,7 +4,7 @@ tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"
 description: Hazelcast Jet Enterprise provides critical management features for scaling in-memory event stream processing across your IT landscape, including Management Center, Security Suite, Lossless Recovery, Rolling Job upgrades, and Enterprise PaaS Deployment Environments.
 name: hazelcast-jet-enterprise
-version: 1.2.0
+version: 1.2.1
 keywords:
 - hazelcast
 - jet

--- a/stable/hazelcast-jet-enterprise/values.yaml
+++ b/stable/hazelcast-jet-enterprise/values.yaml
@@ -173,6 +173,7 @@ metrics:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/path: "/metrics"
+      prometheus.io/port: "8080"
 
 # Hazelcast Jet Management Center application properties
 managementcenter:

--- a/stable/hazelcast-jet/Chart.yaml
+++ b/stable/hazelcast-jet/Chart.yaml
@@ -4,7 +4,7 @@ tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"
 description: Hazelcast Jet is an application embeddable, distributed computing engine built on top of Hazelcast In-Memory Data Grid (IMDG). With Hazelcast IMDG providing storage functionality, Hazelcast Jet performs parallel execution to enable data-intensive applications to operate in near real-time.
 name: hazelcast-jet
-version: 1.3.0
+version: 1.3.1
 keywords:
 - hazelcast
 - jet

--- a/stable/hazelcast-jet/values.yaml
+++ b/stable/hazelcast-jet/values.yaml
@@ -169,6 +169,7 @@ metrics:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/path: "/metrics"
+      prometheus.io/port: "8080"
 
 # Hazelcast Jet Management Center application properties
 managementcenter:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 3.0.2
+version: 3.0.3
 appVersion: "4.0"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -182,6 +182,7 @@ metrics:
     annotations:
       prometheus.io/scrape: "true"
       prometheus.io/path: "/metrics"
+      prometheus.io/port: "8080"
 
 # customVolume is the configuration for any volume mounted as '/data/custom/' (e.g. to mount a volume with custom JARs)
 # customVolume:


### PR DESCRIPTION
Prometheus was trying to scrape additional ports when the scraped port was not being set via `prometheus.io/port` annotation. This could be related to relabeling in Prometheus's configuration.

This PR should fix #74.