### PR TITLE
Do not create Mancenter Config if mancenter.enabled=false

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.1.1
+version: 3.1.2
 appVersion: "4.0"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast-enterprise/templates/mancenter-config.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-config.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mancenter.yaml (not .Values.mancenter.existingConfigMap) }}
+{{- if and .Values.mancenter.enabled (and .Values.mancenter.yaml (not .Values.mancenter.existingConfigMap)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 3.1.0
+version: 3.1.1
 appVersion: "4.0"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast/templates/mancenter-config.yaml
+++ b/stable/hazelcast/templates/mancenter-config.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.mancenter.yaml (not .Values.mancenter.existingConfigMap) }}
+{{- if and .Values.mancenter.enabled (and .Values.mancenter.yaml (not .Values.mancenter.existingConfigMap)) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Fixes a bug that Management Center Config was created even when `mancenter.enabled=false`.