### PR TITLE
inject checksum of hazelcast.yaml into statefulset as an annotations

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.2.2
+version: 3.3.0
 appVersion: "4.0.1"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.14.0-0"

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: hazelcast
+      annotations:
+        checksum/hazelcast-config: {{ toYaml .Values.hazelcast.yaml | sha256sum }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 3.2.2
+version: 3.3.0
 appVersion: "4.0.1"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.14.0-0"

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: hazelcast
+      annotations:
+        checksum/hazelcast-config: {{ toYaml .Values.hazelcast.yaml | sha256sum }}
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
fixes https://github.com/hazelcast/charts/issues/125

All hazelcast pods will be automatically restarted for every hazelcast config changes, sample scenario:

`helm upgrade --set hazelcast.yaml.hazelcast.network.rest-api.endpoint-groups.WAN.enabled=true hz hazelcast/hazelcast`

```
$ kgpow
NAME                        READY   STATUS    RESTARTS   AGE
hz-hazelcast-0             1/1     Running   0          3m8s
hz-hazelcast-1             1/1     Running   0          2m34s
hz-hazelcast-2             1/1     Running   0          2m1s
hz-hazelcast-mancenter-0   1/1     Running   0          3m8s
hz-hazelcast-2   0/1   Terminating   0     2m45s
hz-hazelcast-2   0/1   Pending   0     0s
hz-hazelcast-2   0/1   ContainerCreating   0     0s
hz-hazelcast-2   1/1   Running   0     31s
hz-hazelcast-1   0/1   Terminating   0     3m51s
hz-hazelcast-1   0/1   Pending   0     0s
hz-hazelcast-1   0/1   ContainerCreating   0     0s
hz-hazelcast-1   1/1   Running   0     38s
hz-hazelcast-0   0/1   Terminating   0     5m7s
hz-hazelcast-0   0/1   Pending   0     0s
hz-hazelcast-0   0/1   ContainerCreating   0     0s
hz-hazelcast-0   1/1   Running   0     35s
```

