### PR TITLE
Product version annotation fix

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 2.9.3
+version: 2.9.4
 appVersion: "3.12.9"
 tillerVersion: ">=2.7.2"
 kubeVersion: ">=1.9.0-0"

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         productID: {{ template "hazelcast.fullname" . }}
         productName: Hazelcast Enterprise
-        productVersion: {{ .Values.image.tag }}
+        productVersion: "{{ .Values.image.tag }}"
     spec:
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
When having a version like "3.12" it is considered as a number by k8s and having the following error:

`Error: StatefulSet in version "v1" cannot be handled as a StatefulSet: v1.StatefulSet.Spec: v1.StatefulSetSpec.Template: v1.PodTemplateSpec.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects " or n, but found 3, error found in #10 byte of ...|Version":3.12},"labe|..., bigger context ...|uctName":"Hazelcast Enterprise","productVersion":3.12},"labels":{"app.kubernetes.io/instance":"test1|...`

So using productVersion as a string makes this working in all cases