### PR TITLE
added artifacthub-repo.yml github repo

### DIFF
--- a/.github/workflows/push-charts.yml
+++ b/.github/workflows/push-charts.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - "stable/**"
+      - "artifacthub-repo.yml"
 
 jobs:
   build:
@@ -36,3 +37,7 @@ jobs:
         run: |
           for CHART_TGZ in *.tgz; do aws s3 cp ${CHART_TGZ} s3://hazelcast-charts; done
           aws s3 cp ./index.yaml s3://hazelcast-charts
+
+      - name: Push ArtifactHub metadata YAML to the S3 bucket
+        run: |
+          aws s3 cp ./artifacthub-repo.yml s3://hazelcast-charts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hazelcast Helm Charts
 
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/hazelcast)](https://artifacthub.io/packages/search?repo=hazelcast)
+
 This is a repository for Hazelcast Helm Charts. For more information about installing and using Helm, see its
 [README.md](https://github.com/kubernetes/helm/tree/master/README.md). To get a quick introduction to Charts see this [chart document](https://helm.sh/docs/intro/quickstart/).
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,11 @@
+repositoryID: f53e0666-2684-44fa-926c-1d5761cd8097
+owners:
+  - name: leszko
+    email: rafal@hazelcast.com
+  - name: hasancelik
+    email: hasan@hazelcast.com
+ignore:
+  - name: hazelcast
+    version: latest-snapshot
+  - name: hazelcast-enterprise
+    version: latest-snapshot


### PR DESCRIPTION
At ArtifactHub dashboard, our snapshot charts looks like below:
<img width="314" alt="Screen Shot 2021-01-27 at 13 13 24" src="https://user-images.githubusercontent.com/6005622/105976618-7262a280-60a1-11eb-9c1b-eda2849b67ba.png">

https://artifacthub.io/packages/helm/hazelcast/hazelcast

We deploy `latest-snapshot` charts for internal usage so to remove them I created artifacthub-repo.yml to exclude `latest-snapshot`, here is the related issue below:
https://github.com/artifacthub/hub/issues/973#issuecomment-746411066

This yaml file can be used to put `Official` and `Verified Publisher` badges on our charts. I have already deployed this yaml file to the s3 repo. And I have created an issue for to enable `Official` badge at ArtifactHub dashboard:

<img width="739" alt="Screen Shot 2021-01-27 at 15 54 09" src="https://user-images.githubusercontent.com/6005622/105994037-24a56480-60b8-11eb-9b4c-90ab6be161e2.png">

https://github.com/artifacthub/hub/issues/1054
here is the official docs:
https://artifacthub.io/docs/topics/repositories/#ownership-claim
https://artifacthub.io/docs/topics/repositories/#verified-publisher

I created `Hazelcast Inc.` organization at ArtifactHub and claimed our existing charts via this organization. @leszko if you create an account at ArtifactHub with `leszko` username, I will add you into the org. Your access is already defined as you can see from the yaml file.
