### PR TITLE
Add Helm Chart for Hazelcast-Operator

### DIFF
--- a/stable/hazelcast-operator/.helmignore
+++ b/stable/hazelcast-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/stable/hazelcast-operator/Chart.yaml
+++ b/stable/hazelcast-operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: operator_chart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/stable/hazelcast-operator/templates/_helpers.tpl
+++ b/stable/hazelcast-operator/templates/_helpers.tpl
@@ -35,9 +35,9 @@ Create chart name and version as used by the chart label.
 Create the name of the service account to use
 */}}
 {{- define "hazelcastOperator.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "hazelcastOperator.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.hazelcastOperator.serviceAccount.create -}}
+    {{ default (include "hazelcastOperator.fullname" .) .Values.hazelcastOperator.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
+    {{ default "default" .Values.hazelcastOperator.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/stable/hazelcast-operator/templates/_helpers.tpl
+++ b/stable/hazelcast-operator/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hazelcastOperator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hazelcastOperator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hazelcastOperator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "hazelcastOperator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "hazelcastOperator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/stable/hazelcast-operator/templates/deployment.yaml
+++ b/stable/hazelcast-operator/templates/deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "hazelcastOperator.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcastOperator.name" . }}
+    helm.sh/chart: {{ template "hazelcastOperator.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.hazelcastOperator.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "hazelcastOperator.name" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "hazelcastOperator.name" . }}
+        helm.sh/chart: {{ template "hazelcastOperator.chart" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+      annotations:
+        productID: hazelcast-operator
+        productName: Hazelcast Operator
+        productVersion: {{ .Values.hazelcastOperator.image.version }}
+    spec:
+      serviceAccountName: {{ template "hazelcastOperator.serviceAccountName" . }}
+
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: beta.kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+        - name: {{ template "hazelcastOperator.name" . }}
+          image: {{ printf "%s:%s" .Values.hazelcastOperator.image.repository .Values.hazelcastOperator.image.version }}
+          imagePullPolicy: {{ .Values.hazelcastOperator.image.pullPolicy }}
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: hazelcast-operator
+            - name: RELATED_IMAGE_HAZELCAST
+              value: hazelcast/hazelcast:4.1.1
+            - name: RELATED_IMAGE_MANCENTER
+              value: hazelcast/management-center:4.2020.12
+          resources:
+            limits:
+              cpu: "0.1"
+              memory: 512Mi
+            requests:
+              cpu: "0.1"
+              memory: 256Mi

--- a/stable/hazelcast-operator/templates/hazelcastcluster.crd.yaml
+++ b/stable/hazelcast-operator/templates/hazelcastcluster.crd.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.customResources.Hazelcast.create -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: hazelcasts.hazelcast.com
+spec:
+  group: hazelcast.com
+  names:
+    kind: Hazelcast
+    listKind: HazelcastList
+    plural: hazelcasts
+    singular: hazelcast
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  subresources:
+    status: {}
+{{ end }}

--- a/stable/hazelcast-operator/templates/role.yaml
+++ b/stable/hazelcast-operator/templates/role.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.hazelcastOperator.role.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "hazelcastOperator.fullname" . }}-{{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcastOperator.name" . }}
+    helm.sh/chart: {{ template "hazelcastOperator.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - services
+    - endpoints
+    - persistentvolumeclaims
+    - events
+    - configmaps
+    - secrets
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    - "extensions"
+    resources:
+    - ingresses
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - namespaces
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - get
+    - create
+    - list
+    - update
+    - delete
+  - apiGroups:
+    - rbac.authorization.k8s.io
+    resources:
+    - roles
+    - rolebindings
+    verbs:
+    - get
+    - create
+    - list
+    - update
+    - delete
+  - apiGroups:
+    - apps
+    resources:
+    - deployments
+    - daemonsets
+    - replicasets
+    - statefulsets
+    verbs:
+    - '*'
+  - apiGroups:
+    - monitoring.coreos.com
+    resources:
+    - servicemonitors
+    verbs:
+    - get
+    - create
+  - apiGroups:
+    - apps
+    resourceNames:
+    - hazelcast-operator
+    resources:
+    - deployments/finalizers
+    verbs:
+    - update
+  - apiGroups:
+    - hazelcast.com
+    resources:
+    - '*'
+    verbs:
+    - '*'
+{{- end -}}

--- a/stable/hazelcast-operator/templates/rolebinding.yaml
+++ b/stable/hazelcast-operator/templates/rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.hazelcastOperator.roleBinding.create -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "hazelcastOperator.fullname" . }}-{{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcastOperator.name" . }}
+    helm.sh/chart: {{ template "hazelcastOperator.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+subjects:
+- kind: ServiceAccount
+  name: {{ template "hazelcastOperator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+
+roleRef:
+  kind: ClusterRole
+  name: {{ template "hazelcastOperator.fullname" . }}-{{ .Release.Namespace }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/stable/hazelcast-operator/templates/serviceaccount.yaml
+++ b/stable/hazelcast-operator/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.hazelcastOperator.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "hazelcastOperator.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcastOperator.name" . }}
+    helm.sh/chart: {{ template "hazelcastOperator.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- end -}}

--- a/stable/hazelcast-operator/values.yaml
+++ b/stable/hazelcast-operator/values.yaml
@@ -1,0 +1,25 @@
+fullnameOverride: hazelcast-operator-fullname
+
+nameOverride: hazelcast-operator-name
+
+hazelcastOperator:
+  replicas: 1
+  image:
+    repository: hazelcast/hazelcast-operator
+    version: 0.3.4
+    pullPolicy: IfNotPresent
+
+  serviceAccount:
+    create: true
+    name: hazelcast-operator-saccount
+
+  role:
+    create: true
+
+  roleBinding:
+    create: true
+
+
+customResources:
+  Hazelcast:
+    create: true


### PR DESCRIPTION
Added Helm Chart for Hazelcast operator. The Helm Chart creates the following:
- ClusterRole: For operator, it is optional.
- Service Account: For operator, it is optional.
- RoleBinding: For operator, it is optional.
- Deployment: Deploys operator, not optional.
- CustomResourceDefinition: CRD for resources operator will monitor. Optional.

### TODO
 - [ ] Need to add CI for the chart.
