### PR TITLE
Annotation based Nav Menu integration for CP4MCM

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.7.1
+version: 3.7.2
 appVersion: "4.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/templates/mancenter-mcm-route.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-mcm-route.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.mcm.enabled -}}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ template "mancenter.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: {{ template "mancenter.fullname" . }}
+{{- end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-service.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-service.yaml
@@ -5,6 +5,12 @@ metadata:
 {{- if .Values.mancenter.service.annotations }}
   annotations:
 {{ toYaml .Values.mancenter.service.annotations | indent 4 }}
+{{ else if .Values.mcm.enabled }}
+  annotations:
+    name: Hazelcast Management Center
+    id: administer-mcm
+    roles: ClusterAdministrator,Administrator,Operator,Viewer
+    url: "http://{{ template "mancenter.fullname" . }}-{{ .Release.Namespace }}.{{ .Values.mcm.baseURL }}"
 {{- end }}
   name: {{ template "mancenter.fullname" . }}
   labels:
@@ -12,7 +18,10 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-
+{{- if .Values.mcm.enabled }}
+    inmenu: "true"
+    target: ManagementCenter
+{{- end }}
 spec:
   type: {{ .Values.mancenter.service.type }}
   {{- if .Values.mancenter.service.clusterIP }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -22,6 +22,12 @@ cluster:
   # memberCount is the number Hazelcast members
   memberCount: 3
 
+# Required for IBM CP4MCM deployment
+mcm:
+  enabled: false
+  # Base URL of MCM OpenShift must be defined for CP4MCM versions before 2.3 to enable Management Center at Navigation Menu.
+  baseURL: apps.yellow-22.dev.multicloudops.io
+
 # Hazelcast properties
 hazelcast:
   # enabled is a flag to enable Hazelcast application


### PR DESCRIPTION
To make Management Center reachable from navigation menu for CP4MCM versions before 2.3, some annotation should be added into our enterprise charts and Route resource should be created to expose Management Center service. 

Sample `values.yaml` to enable Nav Menu item:
```
hazelcast:
  licenseKeySecretName: hazelcast-license-key-secret
securityContext:
  enabled: true
  runAsUser: ''
  fsGroup: ''

mcm:
  enabled: true
  baseURL: apps.yellow-22.dev.multicloudops.io

mancenter:
  service:
    type: ClusterIP
```

<img width="468" alt="Screen Shot 2021-04-22 at 11 27 29" src="https://user-images.githubusercontent.com/6005622/115687942-58b0be80-a363-11eb-9353-2ef070844df8.png">


Related [CP4MCM-SDK documentation](https://github.com/IBM/CP4MCM-SDK/tree/master/integration_scenarios/navmenu_integration#deprecated-adding-applications-to-cloudpak-navigation-menu-with-helm-chart-annotations)

Todo:
- [ ] Apply same changes to Jet enterprise charts