### PR TITLE
Custom-Resource based Nav Menu integration for CP4MCM

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.7.2
+version: 3.7.3
 appVersion: "4.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/templates/mancenter-mcm-navmenu.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-mcm-navmenu.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.mcm.enabled (not .Values.mcm.baseURL) -}}
+apiVersion: integrations.sdk.management.ibm.com/v1beta1
+kind: NavMenuEntry
+metadata:
+  name: hazelcast-management-center
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  target: "ManagementCenter"
+  name: "Hazelcast Management Center"
+  parentId: "administer-mcm"
+  roles:
+    - name: ClusterAdministrator
+    - name: Administrator
+    - name: Operator
+    - name: Viewer
+  url: http://{{ template "mancenter.fullname" . }}-{{ .Release.Namespace }}.{{ "{{" }} .OpenShiftBaseUrl {{ "}}" }}
+{{- end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-service.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-service.yaml
@@ -5,7 +5,7 @@ metadata:
 {{- if .Values.mancenter.service.annotations }}
   annotations:
 {{ toYaml .Values.mancenter.service.annotations | indent 4 }}
-{{ else if .Values.mcm.enabled }}
+{{ else if and .Values.mcm.enabled .Values.mcm.baseURL }}
   annotations:
     name: Hazelcast Management Center
     id: administer-mcm
@@ -18,7 +18,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-{{- if .Values.mcm.enabled }}
+{{- if and .Values.mcm.enabled .Values.mcm.baseURL }}
     inmenu: "true"
     target: ManagementCenter
 {{- end }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -26,7 +26,7 @@ cluster:
 mcm:
   enabled: false
   # Base URL of MCM OpenShift must be defined for CP4MCM versions before 2.3 to enable Management Center at Navigation Menu.
-  baseURL: apps.yellow-22.dev.multicloudops.io
+  # baseURL: apps.yellow-22.dev.multicloudops.io
 
 # Hazelcast properties
 hazelcast:


### PR DESCRIPTION
With CP4MCM 2.3 version, SDK operator support will be available so Management Center can be listed at the Navigation Menu via using `NavMenuEntry` custom resource.

depends on #217 

Related [CP4MCM-SDK documentation](https://github.com/IBM/CP4MCM-SDK/tree/master/integration_scenarios/navmenu_integration#adding-applications-to-cloudpak-using-the-navmenuentry-custom-resource)