### PR TITLE
Custom-Resource based SSO integration for CP4MCM

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.7.3
+version: 3.7.4
 appVersion: "4.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/templates/mancenter-mcm-navmenu.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-mcm-navmenu.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   target: "ManagementCenter"
   name: "Hazelcast Management Center"
-  parentId: "administer-mcm"
+  parentId: "applications"
   roles:
     - name: ClusterAdministrator
     - name: Administrator

--- a/stable/hazelcast-enterprise/templates/mancenter-mcm-oidc-client-registration.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-mcm-oidc-client-registration.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.mcm.enabled (not .Values.mcm.baseURL) -}}
+apiVersion: integrations.sdk.management.ibm.com/v1beta1
+kind: OidcClientRegistration
+metadata:
+  name: {{ template "mancenter.fullname" . }}-oidcclientregistration
+  labels:
+    app.kubernetes.io/name: {{ template "hazelcast.name" . }}
+    helm.sh/chart: {{ template "hazelcast.chart" . }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+spec:
+  registration:
+    post_logout_redirect_uris:
+      - http://{{ template "mancenter.fullname" . }}-{{ .Release.Namespace }}.{{ "{{" }} .OpenShiftBaseUrl {{ "}}" }}
+    trusted_uri_prefixes:
+      - http://{{ template "mancenter.fullname" . }}-{{ .Release.Namespace }}.{{ "{{" }} .OpenShiftBaseUrl {{ "}}" }}
+    redirect_uris:
+      - http://{{ template "mancenter.fullname" . }}-{{ .Release.Namespace }}.{{ "{{" }} .OpenShiftBaseUrl {{ "}}" }}/oidc/auth
+    client_secret:
+      secretName: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+      secretKey: client_secret
+    apply_client_secret: true
+{{- end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-service.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-service.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ else if and .Values.mcm.enabled .Values.mcm.baseURL }}
   annotations:
     name: Hazelcast Management Center
-    id: administer-mcm
+    id: applications
     roles: ClusterAdministrator,Administrator,Operator,Viewer
     url: "http://{{ template "mancenter.fullname" . }}-{{ .Release.Namespace }}.{{ .Values.mcm.baseURL }}"
 {{- end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -147,8 +147,69 @@ spec:
         {{- else }}
           value: {{ .Values.hazelcast.licenseKey }}
         {{- end }}
+
+        {{- if and .Values.mcm.enabled (not .Values.mcm.baseURL) }}
+        - name: CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: CLIENT_ID
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: client_secret
+        - name: AUTHORIZE_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: AUTHORIZE_ENDPOINT
+        - name: USER_INFO_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: USER_INFO_ENDPOINT
+        - name: TOKEN_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: TOKEN_ENDPOINT
+        - name: JWK_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: JWK_ENDPOINT
+        - name: OIDC_ISSUER_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: OIDC_ISSUER_URL
+        - name: TRUSTED_URI_PREFIX_0
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "mancenter.fullname" . }}-oidc-reg-secret
+              key: TRUSTED_URI_PREFIX_0
+        - name: MC_INIT_CMD
+          value: "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; ./bin/mc-conf.sh security reset -H /data; ./bin/mc-conf.sh oidc configure -H /data \
+                  --client-id $(CLIENT_ID) \
+                  --client-secret $(CLIENT_SECRET) \
+                  --authorization-endpoint $(AUTHORIZE_ENDPOINT) \
+                  --user-info-endpoint $(USER_INFO_ENDPOINT) \
+                  --token-endpoint $(TOKEN_ENDPOINT) \
+                  --jwk-set-endpoint $(JWK_ENDPOINT) \
+                  --issuer $(OIDC_ISSUER_URL) \
+                  --groups-claim-name 'groups' \
+                  --admin-groups 'icpusers' \
+                  --read-write-groups 'icpusers' \
+                  --read-only-groups 'icpusers' \
+                  --metrics-only-groups 'icpusers' \
+                  --redirect-url $(TRUSTED_URI_PREFIX_0)/oidc/auth \
+                  --user-info-request-http-method POST \
+                  --send-client-info-in-token-request"
+        {{- else }}
         - name: MC_INIT_CMD
           value: "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml"
+        {{- end }}
         - name: JAVA_OPTS
           value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- if .Values.securityContext.enabled }}


### PR DESCRIPTION
depends on: #217 #218 

From [official doc](https://github.com/IBM/CP4MCM-SDK/tree/master/integration_scenarios/SSO#single-sign-on-scenario):
> This is an integration scenario where link(s) to business partner's app have already been embedded into IBM MCM UI. When an user clicks on these links the user should not be prompted to login again on the business partner's website. This is a single sign on (SSO) scenario.
IBM MCM support OIDC and act as an OIDC provider (OP) in the SSO scenario. Business partner’s application should support OIDC and act as an OIDC relying party (RP) during the SSO process.

At the Management Center side, they released OIDC support few months ago. With this PR, we started to use this integration at 2.2 < CP4MCM envs.