### PR TITLE
Updated README to include instructions for how to use Hot Restart with a RO root filesystem

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.7.6
+version: 3.7.7
 appVersion: "4.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -223,7 +223,7 @@ the `hazelcast.yaml` property.
                 resolve-not-ready-addresses: true
             <!-- Custom Configuration Placeholder -->
 
-Note that some of the Hazelcast Enterprise features requires setting `securityContext.readOnlyRootFilesystem` parameter to `false`. This is the case for the Hot Restart feature or enabling security with OpenSSL.
+Note that some of the Hazelcast Enterprise features requires setting `securityContext.readOnlyRootFilesystem` parameter to `false`. This is the case for the Hot Restart feature or enabling security with OpenSSL. In such cases where `readOnlyRootFilesystem` needs to be set to `true` (i.e. a Pod Security Policy requirement), for Hot Restart to work the the JVM parameter `-Djava.io.tmpdir` should be set to a writable location (for example a [custom volume](#adding-custom-jar-files-to-the-imdgmanagement-center-classpath)).
 
 ## Configuring SSL
 


### PR DESCRIPTION
If you have `securityContext.readOnlyRootFilesystem` set to `true` and you enable Hot Restart, you will get an error like the following:

```
Exception in thread "main" com.hazelcast.core.HazelcastException: java.io.IOException: Read-only file system
at com.hazelcast.internal.util.ExceptionUtil.lambda$static$0(ExceptionUtil.java:56)
at com.hazelcast.internal.util.ExceptionUtil.peel(ExceptionUtil.java:134)
at com.hazelcast.internal.util.ExceptionUtil.peel(ExceptionUtil.java:77)
at com.hazelcast.internal.util.ExceptionUtil.rethrow(ExceptionUtil.java:139)
at com.hazelcast.internal.hotrestart.impl.io.TombFileAccessor.initTmpBuffer(TombFileAccessor.java:140)
at com.hazelcast.internal.hotrestart.impl.io.TombFileAccessor.<clinit>(TombFileAccessor.java:102)
...
```

HR requires a directory to write a temporary file, which by default is typically `/tmp` or `/var/tmp`. This will fail with a RO root filesystem. To get around this, the user needs to set `-Djava.io.tmpdir=<writeable-directory>`.

We already mentioned that HR is incompatible with `securityContext.readOnlyRootFilesystem: true`. This addition is to highlight a workaround when the setting is required.