### PR TITLE
[CN-158] Update K8s resource API versions that will be deprecated in K8s version 1.22

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 3.7.11
+version: 3.8.0
 appVersion: "4.2.1"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.mancenter.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "{{ include "mancenter.fullname" . }}"
@@ -30,15 +30,23 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: http
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: http
   {{- end }}
   {{- else }}
-  - http:
-      paths:
-      - backend:
-          serviceName: {{ $serviceName }}
-          servicePort: http
+    - http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: http
   {{- end }}
 {{- end }}

--- a/stable/hazelcast-jet-enterprise/Chart.yaml
+++ b/stable/hazelcast-jet-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.5"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast Jet Enterprise provides critical management features for scaling in-memory event stream processing across your IT landscape, including Management Center, Security Suite, Lossless Recovery, Rolling Job upgrades, and Enterprise PaaS Deployment Environments.
 name: hazelcast-jet-enterprise
-version: 1.12.0
+version: 1.13.0
 keywords:
   - hazelcast
   - jet

--- a/stable/hazelcast-jet-enterprise/templates/management-center-ingress.yaml
+++ b/stable/hazelcast-jet-enterprise/templates/management-center-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managementcenter.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "{{ include "managementcenter.fullname" . }}"
@@ -30,15 +30,23 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: mc-http
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: mc-port
   {{- end }}
   {{- else }}
-  - http:
-      paths:
-      - backend:
-          serviceName: {{ $serviceName }}
-          servicePort: mc-https-port
+    - http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: mc-https-port
   {{- end }}
 {{- end }}

--- a/stable/hazelcast-jet/Chart.yaml
+++ b/stable/hazelcast-jet/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.5"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast Jet is an application embeddable, distributed computing engine built on top of Hazelcast In-Memory Data Grid (IMDG). With Hazelcast IMDG providing storage functionality, Hazelcast Jet performs parallel execution to enable data-intensive applications to operate in near real-time.
 name: hazelcast-jet
-version: 1.11.0
+version: 1.12.0
 keywords:
   - hazelcast
   - jet

--- a/stable/hazelcast-jet/templates/management-center-ingress.yaml
+++ b/stable/hazelcast-jet/templates/management-center-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.managementcenter.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "{{ include "managementcenter.fullname" . }}"
@@ -30,15 +30,23 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: mc-http
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: mc-port
   {{- end }}
   {{- else }}
-  - http:
-      paths:
-      - backend:
-          serviceName: {{ $serviceName }}
-          servicePort: mc-https-port
+    - http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: mc-https-port
   {{- end }}
 {{- end }}

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 3.7.7
+version: 3.8.0
 appVersion: "4.2.1"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast/templates/mancenter-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.mancenter.ingress.enabled -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "{{ include "mancenter.fullname" . }}"
@@ -30,15 +30,23 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          - backend:
-              serviceName: {{ $serviceName }}
-              servicePort: http
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: http
   {{- end }}
   {{- else }}
-  - http:
-      paths:
-      - backend:
-          serviceName: {{ $serviceName }}
-          servicePort: http
+    - http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+                service:
+                  name: {{ $serviceName }}
+                  port:
+                    name: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This repository only uses one apiVersion that will be deprecated: `extensions/v1beta1` and the affected resource kind is `Ingress`.

Changes:
- I updated the `apiVersion` to `networking.k8s.io/v1` with necessary changes in the spec of the manifest. The changes are applied to all Helm Charts.
-  The Ingress resources of Helm Charts `hazelcast-jet` and `hazelcast-jet-enterprise` had an incorrect `servicePort` reference `mc-http` in their spec. I changed it with the correct service port name `mc-port`.