### PR TITLE
Fix ignored service annotations

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.1.0
+version: 5.1.1
 appVersion: "5.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.2.0
+version: 5.3.0
 appVersion: "5.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/templates/service.yaml
+++ b/stable/hazelcast-enterprise/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.mancenter.service.annotations }}
+{{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.1.0
+version: 5.1.1
 appVersion: "5.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.2.0
+version: 5.3.0
 appVersion: "5.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/templates/service.yaml
+++ b/stable/hazelcast/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.mancenter.service.annotations }}
+{{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}


### PR DESCRIPTION
The issue identified was caused by an 'if' statement on the mancenter's service annotations instead of the hazelcast's service itself, which lead to ignored annotations from values.yaml.

The bug affected both hazelcast and hazelcast-enterprise charts.

Effective changes:

{{- if .Values.mancenter.service.annotations }}

becomes 

{{- if .Values.service.annotations }}