### PR TITLE
Update service.yaml

### DIFF
--- a/stable/hazelcast/templates/service.yaml
+++ b/stable/hazelcast/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
   {{- if (and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP)) }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  publishNotReadyAddresses: true
   selector:
     app.kubernetes.io/name: {{ template "hazelcast.name" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"


### PR DESCRIPTION
Updates the service to publish the addresses that aren't ready yet.  Otherwise, the headless service is often not resolvable.