### PR TITLE
Fix indentation issue with `customPorts`

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.3.4
+version: 5.3.5
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.3.5
+version: 5.3.6
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         {{- if .Values.customPorts }}
-{{ toYaml .Values.customPorts | indent 10 }}
+{{ toYaml .Values.customPorts | indent 8 }}
         {{- else }}
         - name: hazelcast
           containerPort: {{ if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.3.5
+version: 5.3.6
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.3.4
+version: 5.3.5
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         {{- if .Values.customPorts }}
-{{ toYaml .Values.customPorts | indent 10 }}
+{{ toYaml .Values.customPorts | indent 8 }}
         {{- else }}
         - name: hazelcast
           containerPort: {{ if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}


### PR DESCRIPTION
Whenever setting `customPorts` in `values.yaml`, the following `values.yaml`
```yaml
customPorts:
  - name: hazelcast
    containerPort: 5701
    hostPort: 5701
  - name: jmx-metrics
    containerPort: 9012
    hostPort: 9012
```
will render the following `statefulset.yaml`:
```yaml
        ports:
          - containerPort: 5701
            hostPort: 5701
            name: hazelcast
          - containerPort: 9012
            hostPort: 9012
            name: jmx-metrics
        - name: metrics
          containerPort: 8080
```

Which the `helm` linter complains with (line 59 is the one with the `metrics` port):
```
Error: YAML parse error on hazelcast/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 59: did not find expected key
```

This PR fixes this issue.