### PR TITLE
Run test pods as a non-privileged users

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.3.6
+version: 5.3.8
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.3.4
+version: 5.3.5
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hazelcast.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,22 +14,34 @@ metadata:
     app.kubernetes.io/component: "test"
     role: test
 spec:
+  {{- if .Values.image.pullSecrets }}
+  imagePullSecrets:
+    {{- range .Values.image.pullSecrets }}
+    - name: {{ . }}
+    {{- end}}
+  {{- end}}
   {{- if .Values.nodeSelector }}
   nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 4 }}
   {{- end }}
   containers:
   - name: "{{ template "hazelcast.fullname" . }}-test"
-    image: "alpine"
+    image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     command:
     - "sh"
     - "-c"
     - |
       set -ex
-      # Install required test tools
-      apk add -q curl
       # Get the number of Hazelcast members in the cluster
       CLUSTER_SIZE=$(curl {{ template "hazelcast.fullname" . }}:{{ .Values.service.port }}/hazelcast/health/cluster-size)
       # Test the correct number of Hazelcast members
       test ${CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
+    resources:
+{{ toYaml .Values.test.resources | indent 6 }}
+    securityContext:
+      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      privileged: false
   restartPolicy: Never
+{{- end }}

--- a/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
@@ -32,7 +32,7 @@ spec:
     - "-c"
     - |
       set -ex
-      {{- if ne .Values.test.securityContext.enabled }}
+      {{- if not .Values.test.securityContext.enabled }}
       # Install required test tools
       apk add -q curl
       {{- end }}

--- a/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
@@ -32,16 +32,22 @@ spec:
     - "-c"
     - |
       set -ex
+      {{- if ne .Values.test.securityContext.enabled }}
+      # Install required test tools
+      apk add -q curl
+      {{- end }}
       # Get the number of Hazelcast members in the cluster
       CLUSTER_SIZE=$(curl {{ template "hazelcast.fullname" . }}:{{ .Values.service.port }}/hazelcast/health/cluster-size)
       # Test the correct number of Hazelcast members
       test ${CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
     resources:
 {{ toYaml .Values.test.resources | indent 6 }}
+    {{- if .Values.test.securityContext.enabled }}
     securityContext:
-      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
-      runAsUser: {{ .Values.securityContext.runAsUser }}
-      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      runAsNonRoot: {{ if eq (int .Values.test.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.test.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.test.securityContext.runAsGroup }}
       privileged: false
+    {{- end }}
   restartPolicy: Never
 {{- end }}

--- a/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
@@ -32,6 +32,10 @@ spec:
     - "-c"
     - |
       set -ex
+      {{- if ne .Values.test.securityContext.enabled }}
+      # Install required test tools
+      apk add -q jq curl
+      {{- end }}
       # Get the HTTP Response Code of the Health Check
       HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/health)
       # Test the MC HTTP RESPONSE CODE
@@ -42,10 +46,12 @@ spec:
       test ${CONNECTED_CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
     resources:
 {{ toYaml .Values.test.resources | indent 6 }}
+    {{- if .Values.test.securityContext.enabled }}
     securityContext:
-      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
-      runAsUser: {{ .Values.securityContext.runAsUser }}
-      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      runAsNonRoot: {{ if eq (int .Values.test.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.test.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.test.securityContext.runAsGroup }}
       privileged: false
+    {{- end }}
   restartPolicy: Never
 {{- end }}

--- a/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
@@ -13,20 +13,24 @@ metadata:
     app.kubernetes.io/component: "test"
     role: test
 spec:
+  {{- if .Values.image.pullSecrets }}
+  imagePullSecrets:
+    {{- range .Values.image.pullSecrets }}
+    - name: {{ . }}
+    {{- end}}
+  {{- end}}
   {{- if .Values.nodeSelector }}
   nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 4 }}
   {{- end }}
   containers:
   - name: "{{ template "mancenter.fullname" . }}-test"
-    image: "alpine"
+    image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     command:
     - "sh"
     - "-c"
     - |
       set -ex
-      # Install required test tools
-      apk add -q jq curl
       # Get the HTTP Response Code of the Health Check
       HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/health)
       # Test the MC HTTP RESPONSE CODE
@@ -35,4 +39,12 @@ spec:
       CONNECTED_CLUSTER_SIZE=$(curl --silent {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/rest/clusters/dev/members | jq '. | length')
       # Test the correct number of Hazelcast members
       test ${CONNECTED_CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
+    resources:
+{{ toYaml .Values.test.resources | indent 6 }}
+    securityContext:
+      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      privileged: false
   restartPolicy: Never
+{{- end }}

--- a/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mancenter.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
@@ -32,7 +32,7 @@ spec:
     - "-c"
     - |
       set -ex
-      {{- if ne .Values.test.securityContext.enabled }}
+      {{- if not .Values.test.securityContext.enabled }}
       # Install required test tools
       apk add -q jq curl
       {{- end }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -453,7 +453,7 @@ test:
   ## Hazelcast chart test hook image version
   image:
     # repository is the chart test hook image name
-    repository: "alpine/curl"
+    repository: "alpine"
     # tag is the chart test hook image tag
     tag: "latest"
     # pullPolicy is the Docker image pull policy
@@ -462,13 +462,11 @@ test:
     #
     pullPolicy: IfNotPresent
 
-  # Configure resource requests and limits
-  # ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  #
-  # resources:
-  #   requests:
-  #     memory: 256Mi
-  #     cpu: 100m
-  #   limits:
-  #     memory: 1024Mi
-  #     cpu: 200m
+  # Security Context properties
+  securityContext:
+    # enabled is a flag to enable Security Context
+    enabled: false
+    # runAsUser is the user ID used to run the container
+    runAsUser: 65534
+    # runAsGroup is the primary group ID used to run all processes within any container of the pod
+    runAsGroup: 65534

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -448,3 +448,27 @@ mancenter:
 
   # secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
   # secretsMountName:
+
+test:
+  ## Hazelcast chart test hook image version
+  image:
+    # repository is the chart test hook image name
+    repository: "alpine/curl"
+    # tag is the chart test hook image tag
+    tag: "latest"
+    # pullPolicy is the Docker image pull policy
+    # It's recommended to change this to 'Always' if the image tag is 'latest'
+    # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+    #
+    pullPolicy: IfNotPresent
+
+  # Configure resource requests and limits
+  # ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  #
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+  #   limits:
+  #     memory: 1024Mi
+  #     cpu: 200m

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.3.4
+version: 5.3.5
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.3.6
+version: 5.3.8
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast/templates/tests/test-hazelcast.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hazelcast.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,22 +14,34 @@ metadata:
     app.kubernetes.io/component: "test"
     role: test
 spec:
+  {{- if .Values.image.pullSecrets }}
+  imagePullSecrets:
+    {{- range .Values.image.pullSecrets }}
+    - name: {{ . }}
+    {{- end}}
+  {{- end}}
   {{- if .Values.nodeSelector }}
   nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 4 }}
   {{- end }}
   containers:
   - name: "{{ template "hazelcast.fullname" . }}-test"
-    image: "alpine"
+    image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     command:
     - "sh"
     - "-c"
     - |
       set -ex
-      # Install required test tools
-      apk add -q curl
       # Get the number of Hazelcast members in the cluster
       CLUSTER_SIZE=$(curl {{ template "hazelcast.fullname" . }}:{{ .Values.service.port }}/hazelcast/health/cluster-size)
       # Test the correct number of Hazelcast members
       test ${CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
+    resources:
+{{ toYaml .Values.test.resources | indent 6 }}
+    securityContext:
+      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      privileged: false
   restartPolicy: Never
+{{- end }}

--- a/stable/hazelcast/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast/templates/tests/test-hazelcast.yaml
@@ -32,16 +32,22 @@ spec:
     - "-c"
     - |
       set -ex
+      {{- if not .Values.test.securityContext.enabled }}
+      # Install required test tools
+      apk add -q curl
+      {{- end }}
       # Get the number of Hazelcast members in the cluster
       CLUSTER_SIZE=$(curl {{ template "hazelcast.fullname" . }}:{{ .Values.service.port }}/hazelcast/health/cluster-size)
       # Test the correct number of Hazelcast members
       test ${CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
     resources:
 {{ toYaml .Values.test.resources | indent 6 }}
+    {{- if .Values.test.securityContext.enabled }}
     securityContext:
-      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
-      runAsUser: {{ .Values.securityContext.runAsUser }}
-      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      runAsNonRoot: {{ if eq (int .Values.test.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.test.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.test.securityContext.runAsGroup }}
       privileged: false
+    {{- end }}
   restartPolicy: Never
 {{- end }}

--- a/stable/hazelcast/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast/templates/tests/test-management-center.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mancenter.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -13,20 +14,24 @@ metadata:
     app.kubernetes.io/component: "test"
     role: test
 spec:
+  {{- if .Values.image.pullSecrets }}
+  imagePullSecrets:
+    {{- range .Values.image.pullSecrets }}
+    - name: {{ . }}
+    {{- end}}
+  {{- end}}
   {{- if .Values.nodeSelector }}
   nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 4 }}
   {{- end }}
   containers:
   - name: "{{ template "mancenter.fullname" . }}-test"
-    image: "alpine"
+    image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
     command:
     - "sh"
     - "-c"
     - |
       set -ex
-      # Install required test tools
-      apk add -q jq curl
       # Get the HTTP Response Code of the Health Check
       HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/health)
       # Test the MC HTTP RESPONSE CODE
@@ -35,4 +40,12 @@ spec:
       CONNECTED_CLUSTER_SIZE=$(curl --silent {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/rest/clusters/dev/members | jq '. | length')
       # Test the correct number of Hazelcast members
       test ${CONNECTED_CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
+    resources:
+{{ toYaml .Values.test.resources | indent 6 }}
+    securityContext:
+      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      privileged: false
   restartPolicy: Never
+{{- end }}

--- a/stable/hazelcast/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast/templates/tests/test-management-center.yaml
@@ -32,6 +32,10 @@ spec:
     - "-c"
     - |
       set -ex
+      {{- if not .Values.test.securityContext.enabled }}
+      # Install required test tools
+      apk add -q jq curl
+      {{- end }}
       # Get the HTTP Response Code of the Health Check
       HEALTH_CHECK_HTTP_RESPONSE_CODE=$(curl --write-out %{http_code} --silent --output /dev/null {{ template "mancenter.fullname" . }}:{{ .Values.mancenter.service.port }}{{ .Values.mancenter.contextPath }}/health)
       # Test the MC HTTP RESPONSE CODE
@@ -42,10 +46,12 @@ spec:
       test ${CONNECTED_CLUSTER_SIZE} -eq {{ .Values.cluster.memberCount }}
     resources:
 {{ toYaml .Values.test.resources | indent 6 }}
+    {{- if .Values.test.securityContext.enabled }}
     securityContext:
-      runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
-      runAsUser: {{ .Values.securityContext.runAsUser }}
-      runAsGroup: {{ .Values.securityContext.runAsGroup }}
+      runAsNonRoot: {{ if eq (int .Values.test.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
+      runAsUser: {{ .Values.test.securityContext.runAsUser }}
+      runAsGroup: {{ .Values.test.securityContext.runAsGroup }}
       privileged: false
+    {{- end }}
   restartPolicy: Never
 {{- end }}

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -405,3 +405,27 @@ mancenter:
     create: true
   # secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
   # secretsMountName:
+
+test:
+  ## Hazelcast chart test hook image version
+  image:
+    # repository is the chart test hook image name
+    repository: "alpine/curl"
+    # tag is the chart test hook image tag
+    tag: "latest"
+    # pullPolicy is the Docker image pull policy
+    # It's recommended to change this to 'Always' if the image tag is 'latest'
+    # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
+    #
+    pullPolicy: IfNotPresent
+
+  # Configure resource requests and limits
+  # ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  #
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+  #   limits:
+  #     memory: 1024Mi
+  #     cpu: 200m

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -410,7 +410,7 @@ test:
   ## Hazelcast chart test hook image version
   image:
     # repository is the chart test hook image name
-    repository: "alpine/curl"
+    repository: "alpine"
     # tag is the chart test hook image tag
     tag: "latest"
     # pullPolicy is the Docker image pull policy
@@ -418,6 +418,15 @@ test:
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
     #
     pullPolicy: IfNotPresent
+
+  # Security Context properties
+  securityContext:
+    # enabled is a flag to enable Security Context
+    enabled: false
+    # runAsUser is the user ID used to run the container
+    runAsUser: 65534
+    # runAsGroup is the primary group ID used to run all processes within any container of the pod
+    runAsGroup: 65534
 
   # Configure resource requests and limits
   # ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
With this PR users will be able to run helm chart test hook containers as a non-privileged user.

- Use `alpine/curl` image instead of `alpine` image and no need to install curl package at the runtime.
- Inherit security context from main app.
- Inherit `imagePullSecrets` from main app.
- Disable test if the main app is disabled.