### PR TITLE
Add option to use k8s Roles and RoleBindings

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.3.6
+version: 5.3.7
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.3.4
+version: 5.3.6
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG Enterprise is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -110,6 +110,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |service.clusterIP|IP of the service, `None` makes the service headless|None|
 |service.port|Kubernetes service port|5701|
 |rbac.create|Enable installing RBAC Role authorization|true|
+|rbac.useClusterRole|If `rbac.create` is true, this will create a cluster role. Set this to false to use role and role binding instead of cluster role and cluster role binding.|true|
 |serviceAccount.create|Enable installing Service Account|true|
 |serviceAccount.automountToken|Whether the token associated with the service account should be automatically mounted|true|
 |serviceAccount.name|Name of Service Account, if not set, the name is generated using the fullname template|nil|

--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -110,7 +110,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |service.clusterIP|IP of the service, `None` makes the service headless|None|
 |service.port|Kubernetes service port|5701|
 |rbac.create|Enable installing RBAC Role authorization|true|
-|rbac.useClusterRole|If `rbac.create` is true, this will create a cluster role. Set this to false to use role and role binding instead of cluster role and cluster role binding.|true|
+|rbac.useClusterRole|If `rbac.create` is true, this will create a cluster role. Set this to false to use role and role binding. But note that some discovery features will be unavailable.|true|
 |serviceAccount.create|Enable installing Service Account|true|
 |serviceAccount.automountToken|Whether the token associated with the service account should be automatically mounted|true|
 |serviceAccount.name|Name of Service Account, if not set, the name is generated using the fullname template|nil|

--- a/stable/hazelcast-enterprise/templates/NOTES.txt
+++ b/stable/hazelcast-enterprise/templates/NOTES.txt
@@ -1,6 +1,11 @@
 {{- if .Values.hazelcast.enabled }}
 ** Hazelcast cluster is being deployed! **
 
+{{- if not .Values.rbac.useClusterRole }}
+** Caution:
+   Deployment is configured with a Role instead of the default ClusterRole. Hence, some features will be unavailable.
+{{- end }}
+
 -------------------------------------------------------------------------------
 
 To access Hazelcast within the Kubernetes cluster:

--- a/stable/hazelcast-enterprise/templates/role.yaml
+++ b/stable/hazelcast-enterprise/templates/role.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.useClusterRole }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: {{ template "hazelcast.fullname" . }}-{{ .Release.Namespace }}
   labels:

--- a/stable/hazelcast-enterprise/templates/role.yaml
+++ b/stable/hazelcast-enterprise/templates/role.yaml
@@ -20,7 +20,7 @@ rules:
   - pods
 {{- if .Values.rbac.useClusterRole }}
   - nodes
-{{- else }}
+{{- end }}
   - services
   verbs:
   - get

--- a/stable/hazelcast-enterprise/templates/role.yaml
+++ b/stable/hazelcast-enterprise/templates/role.yaml
@@ -18,7 +18,9 @@ rules:
   resources:
   - endpoints
   - pods
+{{- if .Values.rbac.useClusterRole }}
   - nodes
+{{- else }}
   - services
   verbs:
   - get

--- a/stable/hazelcast-enterprise/templates/rolebinding.yaml
+++ b/stable/hazelcast-enterprise/templates/rolebinding.yaml
@@ -14,7 +14,11 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.rbac.useClusterRole }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: {{ template "hazelcast.fullname" . }}-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount

--- a/stable/hazelcast-enterprise/templates/rolebinding.yaml
+++ b/stable/hazelcast-enterprise/templates/rolebinding.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.useClusterRole }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 metadata:
   name: {{ template "hazelcast.fullname" . }}-{{ .Release.Namespace }}
   labels:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -196,6 +196,8 @@ rbac:
   # Specifies whether RBAC resources should be created
   # It is not required if DNS Lookup is used (https://github.com/hazelcast/hazelcast-kubernetes#dns-lookup)
   create: true
+  # Set this to false to use kubernetes Role and RoleBinding instead of ClusterRole and ClusterRoleBinding.
+  useClusterRole: true
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.3.6
+version: 5.3.7
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.3.4
+version: 5.3.6
 appVersion: "5.0.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast IMDG is the most widely used in-memory data grid with hundreds of thousands of installed clusters around the world. It offers caching solutions ensuring that data is in the right place when it’s needed for optimal performance.

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -106,6 +106,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | service.port | Kubernetes service port| 5701|
 | service.clusterIP| IP of the service, "None" makes the service headless| None|
 | rbac.create| Enable installing RBAC Role authorization | true|
+| rbac.useClusterRole | If `rbac.create` is true, this will create a cluster role. Set this to false to use role and role binding instead of cluster role and cluster role binding. | true|
 | serviceAccount.create | Enable installing Service Account| true|
 | serviceAccount.automountToken | Whether the token associated with the service account should be automatically mounted | true|
 | serviceAccount.name | Name of Service Account, if not set, the name is generated using the fullname template| nil |

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -106,7 +106,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | service.port | Kubernetes service port| 5701|
 | service.clusterIP| IP of the service, "None" makes the service headless| None|
 | rbac.create| Enable installing RBAC Role authorization | true|
-| rbac.useClusterRole | If `rbac.create` is true, this will create a cluster role. Set this to false to use role and role binding instead of cluster role and cluster role binding. | true|
+| rbac.useClusterRole | If `rbac.create` is true, this will create a cluster role. Set this to false to use role and role binding. But note that some discovery features will be unavailable. | true |
 | serviceAccount.create | Enable installing Service Account| true|
 | serviceAccount.automountToken | Whether the token associated with the service account should be automatically mounted | true|
 | serviceAccount.name | Name of Service Account, if not set, the name is generated using the fullname template| nil |

--- a/stable/hazelcast/templates/NOTES.txt
+++ b/stable/hazelcast/templates/NOTES.txt
@@ -1,6 +1,11 @@
 {{- if .Values.hazelcast.enabled }}
 ** Hazelcast cluster is being deployed! **
 
+{{- if not .Values.rbac.useClusterRole }}
+** Caution:
+   Deployment is configured with a Role instead of the default ClusterRole. Hence, some features will be unavailable.
+{{- end }}
+
 -------------------------------------------------------------------------------
 
 To access Hazelcast within the Kubernetes cluster:

--- a/stable/hazelcast/templates/role.yaml
+++ b/stable/hazelcast/templates/role.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.useClusterRole }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: {{ template "hazelcast.fullname" . }}-{{ .Release.Namespace }}
   labels:

--- a/stable/hazelcast/templates/role.yaml
+++ b/stable/hazelcast/templates/role.yaml
@@ -20,7 +20,7 @@ rules:
   - pods
 {{- if .Values.rbac.useClusterRole }}
   - nodes
-{{- else }}
+{{- end }}
   - services
   verbs:
   - get

--- a/stable/hazelcast/templates/role.yaml
+++ b/stable/hazelcast/templates/role.yaml
@@ -18,7 +18,9 @@ rules:
   resources:
   - endpoints
   - pods
+{{- if .Values.rbac.useClusterRole }}
   - nodes
+{{- else }}
   - services
   verbs:
   - get

--- a/stable/hazelcast/templates/rolebinding.yaml
+++ b/stable/hazelcast/templates/rolebinding.yaml
@@ -14,7 +14,11 @@ metadata:
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+{{- if .Values.rbac.useClusterRole }}
   kind: ClusterRole
+{{- else }}
+  kind: Role
+{{- end }}
   name: {{ template "hazelcast.fullname" . }}-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount

--- a/stable/hazelcast/templates/rolebinding.yaml
+++ b/stable/hazelcast/templates/rolebinding.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.rbac.useClusterRole }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 metadata:
   name: {{ template "hazelcast.fullname" . }}-{{ .Release.Namespace }}
   labels:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -171,6 +171,8 @@ rbac:
   # Specifies whether RBAC resources should be created
   # It is not required if DNS Lookup is used (https://github.com/hazelcast/hazelcast-kubernetes#dns-lookup)
   create: true
+  # Set this to false to use kubernetes Role and RoleBinding instead of ClusterRole and ClusterRoleBinding.
+  useClusterRole: true
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
Not all k8s clusters allow to create ClusterRoles and ClusterRoleBindings. This option allows users to create Roles and RoleBindings instead.