### PR TITLE
add image digest

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.4.0
+version: 5.4.1
 appVersion: "5.1.1"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -66,7 +66,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "mancenter.fullname" . }}
+        {{- if empty .Values.mancenter.image.tag }}
+        image: "{{ .Values.mancenter.image.repository }}@{{ .Values.mancenter.image.digest }}"
+        {{- else }}
         image: "{{ .Values.mancenter.image.repository }}:{{ .Values.mancenter.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.mancenter.image.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.mancenter.resources | indent 10 }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -78,10 +78,10 @@ spec:
 {{- end }}
       containers:
       - name: {{ template "hazelcast.fullname" . }}
-        {{- if .Values.image.tag }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else }}
+        {{- if empty .Values.image.tag }}
         image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -78,7 +78,11 @@ spec:
 {{- end }}
       containers:
       - name: {{ template "hazelcast.fullname" . }}
+        {{- if .Values.image.tag }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -296,7 +296,7 @@ mancenter:
     repository: "hazelcast/management-center"
     # tag is the Hazelcast Management Center image tag
     tag: "5.1.2"
-    # digest is the Hazelcast image digest that will be used only if the tag is empty
+    # digest is the Hazelcast Management Center image digest that will be used only if the tag is empty
     digest: ""
     #
     # pullPolicy is the Docker image pull policy

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -6,6 +6,9 @@ image:
   repository: "hazelcast/hazelcast-enterprise"
   # tag is the Hazelcast image tag
   tag: "5.1.1"
+  # digest is the Hazelcast image digest that will be used only if the tag is empty
+  digest: ""
+  #
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -296,6 +296,9 @@ mancenter:
     repository: "hazelcast/management-center"
     # tag is the Hazelcast Management Center image tag
     tag: "5.1.2"
+    # digest is the Hazelcast image digest that will be used only if the tag is empty
+    digest: ""
+    #
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.4.0
+version: 5.4.1
 appVersion: "5.1.1"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -66,7 +66,11 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "mancenter.fullname" . }}
+        {{- if empty .Values.mancenter.image.tag }}
+        image: "{{ .Values.mancenter.image.repository }}@{{ .Values.mancenter.image.digest }}"
+        {{- else }}
         image: "{{ .Values.mancenter.image.repository }}:{{ .Values.mancenter.image.tag }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.mancenter.image.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.mancenter.resources | indent 10 }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -78,10 +78,10 @@ spec:
 {{- end }}
       containers:
       - name: {{ template "hazelcast.fullname" . }}
-        {{- if .Values.image.tag }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        {{- else }}
+        {{- if empty .Values.image.tag }}
         image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -78,7 +78,11 @@ spec:
 {{- end }}
       containers:
       - name: {{ template "hazelcast.fullname" . }}
+        {{- if .Values.image.tag }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
+        image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -254,6 +254,8 @@ mancenter:
     repository: "hazelcast/management-center"
     # tag is the Hazelcast Management Center image tag
     tag: "5.1.2"
+    # digest is the Hazelcast image digest that will be used only if the tag is empty
+    digest: ""
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -6,6 +6,9 @@ image:
   repository: "hazelcast/hazelcast"
   # tag is the Hazelcast image tag
   tag: "5.1.1"
+  # digest is the Hazelcast image digest that will be used only if the tag is empty
+  digest: ""
+  #
   # pullPolicy is the Docker image pull policy
   # It's recommended to change this to 'Always' if the image tag is 'latest'
   # ref: http://kubernetes.io/docs/user-guide/images/#updating-images

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -254,7 +254,7 @@ mancenter:
     repository: "hazelcast/management-center"
     # tag is the Hazelcast Management Center image tag
     tag: "5.1.2"
-    # digest is the Hazelcast image digest that will be used only if the tag is empty
+    # digest is the Hazelcast Management Center image digest that will be used only if the tag is empty
     digest: ""
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'


### PR DESCRIPTION
Add the possibility to use the image `digest` instead of the `tag`. The `digest` will be used only if the `tag` is not set.