### PR TITLE
Remove helm chart version from volumeClaimTemplate's metadata

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.4.6
+version: 5.4.7
 appVersion: "5.1.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.
 keywords:
-- hazelcast
-- keyvalue
-- in-memory
-- database
-- caching
+  - hazelcast
+  - keyvalue
+  - in-memory
+  - database
+  - caching
 home: https://hazelcast.com/products/
 icon: https://hazelcast.com/brand-assets/files/hazelcast-stacked-flat-sm.png
 maintainers:
-- name: Hazelcast Cloud Native Team
-  email: cloudnative@hazelcast.com
-- name: hasancelik
-  email: hasan@hazelcast.com
+  - name: Hazelcast Cloud Native Team
+    email: cloudnative@hazelcast.com
+  - name: hasancelik
+    email: hasan@hazelcast.com
 engine: gotpl

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -277,7 +277,7 @@ spec:
       name: mancenter-storage
       labels:
         app.kubernetes.io/name: {{ template "mancenter.name" . }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     spec:

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -239,7 +239,7 @@ spec:
       name: hot-restart-persistence
       labels:
         app.kubernetes.io/name: {{ template "hazelcast.name" . }}
-        helm.sh/chart: {{ template "hazelcast.chart" . }}
+        helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     spec:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,22 +1,22 @@
 apiVersion: v1
 name: hazelcast
-version: 5.4.6
+version: 5.4.7
 appVersion: "5.1.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.
 keywords:
-- hazelcast
-- keyvalue
-- in-memory
-- database
-- caching
+  - hazelcast
+  - keyvalue
+  - in-memory
+  - database
+  - caching
 home: https://hazelcast.com/open-source-projects/
 icon: https://hazelcast.com/brand-assets/files/hazelcast-stacked-flat-sm.png
 sources:
-- https://github.com/hazelcast/hazelcast
+  - https://github.com/hazelcast/hazelcast
 maintainers:
-- name: Hazelcast Cloud Native Team
-  email: cloudnative@hazelcast.com
-- name: hasancelik
-  email: hasan@hazelcast.com
+  - name: Hazelcast Cloud Native Team
+    email: cloudnative@hazelcast.com
+  - name: hasancelik
+    email: hasan@hazelcast.com
 engine: gotpl

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -209,7 +209,7 @@ spec:
       name: mancenter-storage
       labels:
         app.kubernetes.io/name: {{ template "mancenter.name" . }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     spec:


### PR DESCRIPTION
When updating the helm release with a new version it gives following
error.

  * spec: Forbidden: updates to statefulset spec for fields other
  than 'replicas', 'template', and 'updateStrategy' are forbidden

This is because version in `helm.sh/chart:` of volumeClaimTemplate's
metadata change due to the release version update but at the moment
`spec.volumeClaimTemplate` is not allowed to change by the k8s APIs.