### PR TITLE
remove duplicated security context fields in mancenter-statefulset.yaml

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.4.2
+version: 5.4.3
 appVersion: "5.1.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -231,6 +231,7 @@ spec:
         securityContext:
           runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}
           runAsUser: {{ .Values.securityContext.runAsUser }}
+          runAsGroup: {{ .Values.securityContext.runAsGroup }}
           privileged: false
           readOnlyRootFilesystem: false
           allowPrivilegeEscalation: false

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -238,10 +238,6 @@ spec:
             drop:
             - ALL
         {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
       {{- if .Values.mancenter.priorityClassName }}
       priorityClassName: "{{ .Values.mancenter.priorityClassName }}"
       {{- end }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -217,6 +217,8 @@ securityContext:
   enabled: true
   # runAsUser is the user ID used to run the container
   runAsUser: 65534
+  # runAsGroup is the primary group ID used to run all processes within any container of the pod
+  runAsGroup: 65534
   # fsGroup is the group ID associated with the container
   fsGroup: 65534
   # readOnlyRootFilesystem is a flag to enable readOnlyRootFilesystem for the Hazelcast security context

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.4.2
+version: 5.4.3
 appVersion: "5.1.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -171,10 +171,6 @@ spec:
             drop:
             - ALL
         {{- end }}
-      {{- if .Values.securityContext.enabled }}
-      securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-      {{- end }}
       {{- if .Values.mancenter.priorityClassName }}
       priorityClassName: "{{ .Values.mancenter.priorityClassName }}"
       {{- end }}


### PR DESCRIPTION
I removed the duplicated securityContext fields in mancenter-statefulset.yaml files.

```yaml
{{- if .Values.securityContext.enabled }}
  securityContext:
    fsGroup: {{ .Values.securityContext.fsGroup }}
{{- end }}
``` 

These duplicated fields cause to error when building templates by kustomize.

```
mapping key "securityContext" already defined
```
see also #278
