### PR TITLE
fix empty values and lines in rendered yaml templates

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.4.3
+version: 5.4.4
 appVersion: "5.1.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -156,10 +156,10 @@ spec:
         - name: MC_LICENSE_KEY
           value: {{ .Values.hazelcast.licenseKey }}
         {{- end }}
-        {{ $clusterConfigCommand := "" }}
-        {{ if .Values.mancenter.clusterConfig.create }}
-        {{ $clusterConfigCommand = "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; " }}
-        {{ end }}
+        {{- $clusterConfigCommand := "" }}
+        {{- if .Values.mancenter.clusterConfig.create }}
+        {{- $clusterConfigCommand = "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; " }}
+        {{- end }}
         {{- if and .Values.mcm.enabled (not .Values.mcm.baseURL) }}
         - name: CLIENT_ID
           valueFrom:

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- range $key, $val := .Values.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
-  {{- end}}
+  {{- end }}
 spec:
   serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -8,10 +8,12 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  {{- if .Values.annotations }}
   annotations:
     {{- range $key, $val := .Values.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end}}
 spec:
   serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}
@@ -92,7 +94,9 @@ spec:
         {{- else }}
         - name: hazelcast
           containerPort: {{ if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
+          {{- if .Values.hostPort }}
           hostPort: {{ .Values.hostPort }}
+          {{- end }}
         {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: {{ .Values.metrics.service.portName }}
@@ -226,8 +230,8 @@ spec:
         - name: hazelcast-external
 {{ toYaml .Values.externalVolume | indent 10 }}
         {{- end }}
-  volumeClaimTemplates:
   {{- if and (and (eq .Values.hotRestart.enabled true) (empty .Values.hotRestart.existingClaim)) (empty .Values.hotRestart.hostPath) }}
+  volumeClaimTemplates:
   - metadata:
       name: hot-restart-persistence
       labels:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.4.3
+version: 5.4.4
 appVersion: "5.1.2"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -146,11 +146,11 @@ spec:
         - name: MC_LICENSE_KEY
           value: {{ .Values.mancenter.licenseKey }}
         {{- end }}
-        {{ $clusterConfigCommand := "" }}
-        {{ if .Values.mancenter.clusterConfig.create }}
-        {{ $clusterConfigCommand = "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; " }}
-        {{ end }}
-        {{ if .Values.mancenter.devMode.enabled }}
+        {{- $clusterConfigCommand := "" }}
+        {{- if .Values.mancenter.clusterConfig.create }}
+        {{- $clusterConfigCommand = "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; " }}
+        {{- end }}
+        {{- if .Values.mancenter.devMode.enabled }}
         - name: MC_INIT_CMD
           value: "{{ $clusterConfigCommand }}./bin/mc-conf.sh dev-mode configure"
         {{- else if .Values.mancenter.clusterConfig.create }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- range $key, $val := .Values.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
-  {{- end}} 
+  {{- end }} 
 spec:
   serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -8,10 +8,12 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+  {{- if .Values.annotations }}
   annotations:
     {{- range $key, $val := .Values.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- end}} 
 spec:
   serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}
@@ -92,7 +94,9 @@ spec:
         {{- else }}
         - name: hazelcast
           containerPort: {{ if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
+          {{- if .Values.hostPort }}
           hostPort: {{ .Values.hostPort }}
+          {{- end }}
         {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: {{ .Values.metrics.service.portName }}


### PR DESCRIPTION
remove empty lines:

mancenter-statefulset.yaml

```yaml
env:





        - name: MC_INIT_CMD
          value: "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; "
        - name: JAVA_OPTS
```

remove empty values:

statefulset.yaml

```yaml
metadata:
  ...
  annotations:
spec:
  serviceName: release-name-hazelcast
```

statefulset.yaml

```yaml
ports:
  - name: hazelcast
     containerPort: 5701
     hostPort:
livenessProbe:
  ...
```

