### PR TITLE
Adapt helm chart for persistence improvements in 5.2

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.5.0
+version: 5.5.1
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/role.yaml
+++ b/stable/hazelcast-enterprise/templates/role.yaml
@@ -15,6 +15,9 @@ metadata:
 rules:
 - apiGroups:
   - ""
+{{- if .Values.hotRestart.enabled}}
+  - apps
+{{- end}}
   resources:
   - endpoints
   - pods
@@ -22,7 +25,13 @@ rules:
   - nodes
 {{- end }}
   - services
+{{- if .Values.hotRestart.enabled}}
+  - statefulsets
+{{- end}}
   verbs:
   - get
   - list
+{{- if .Values.hotRestart.enabled}}
+  - watch
+{{- end}}
 {{- end -}}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -120,7 +120,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ .Values.readinessProbe.path }}
+            path: {{ if .Values.hotRestart.enabled}} /hazelcast/health/ready {{ else }} {{ .Values.readinessProbe.path }} {{ end }}
             port: {{ if .Values.readinessProbe.port }}{{ .Values.readinessProbe.port }}{{ else if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
             scheme: {{ .Values.readinessProbe.scheme }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -172,7 +172,7 @@ spec:
           value: "{{ .Values.metrics.service.port }}"
         {{- end }}
         - name: JAVA_OPTS
-          value: "-Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.hotRestart={{ .Values.hotRestart.enabled }} -Dhz.jet.enabled={{ .Values.jet.enabled }} {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} -Dhazelcast.cluster.version.auto.upgrade.enabled={{ .Values.hazelcast.updateClusterVersionAfterRollingUpgrade }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
+          value: "-Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.hotRestart={{ .Values.hotRestart.enabled }} {{ if .Values.hotRestart.enabled }}-Dhazelcast.stale.join.prevention.duration.seconds=5{{ end }} -Dhz.jet.enabled={{ .Values.jet.enabled }} {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} -Dhazelcast.cluster.version.auto.upgrade.enabled={{ .Values.hazelcast.updateClusterVersionAfterRollingUpgrade }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
         {{- if .Values.hazelcast.loggingLevel }}
         - name: LOGGING_LEVEL
           value: {{ .Values.hazelcast.loggingLevel }}


### PR DESCRIPTION
When hotRestart is enabled:
- Use /hazelcast/health/ready readiness probe to allow for proper cluster-wide recovery from persistence
- Allow watch verb on statefulsets resources, so Hazelcast can monitor statefulset spec & status changes and make informed decisions about member/cluster shutdown and startup
- Reduce default stale join timeout from 30 to 5 seconds, so rescheduled pods can rejoin the cluster without trouble