### PR TITLE
Use /health/ready endpoint for the readinessProbe

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.5.1
+version: 5.5.2
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.5.2
+version: 5.6.0
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |readinessProbe.timeoutSeconds|When the probe times out|1|
 |readinessProbe.successThreshold|Minimum consecutive successes for the probe to be considered successful after having failed|1|
 |readinessProbe.failureThreshold|Minimum consecutive failures for the probe to be considered failed after having succeeded.|3|
-|readinessProbe.path|URL path that will be called to check readiness.|/hazelcast/health/node-state|
+|readinessProbe.path|URL path that will be called to check readiness.|/hazelcast/health/ready|
 |readinessProbe.port|Port that will be used in readiness probe calls.|nil|
 |readinessProbe.scheme|HTTPS or HTTP scheme.|HTTP|
 |resources.limits.cpu|CPU resource limit|default|

--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |readinessProbe.timeoutSeconds|When the probe times out|1|
 |readinessProbe.successThreshold|Minimum consecutive successes for the probe to be considered successful after having failed|1|
 |readinessProbe.failureThreshold|Minimum consecutive failures for the probe to be considered failed after having succeeded.|3|
-|readinessProbe.path|URL path that will be called to check readiness.|/hazelcast/health/ready|
+|readinessProbe.path|URL path that will be called to check readiness.|/hazelcast/health/node-state|
 |readinessProbe.port|Port that will be used in readiness probe calls.|nil|
 |readinessProbe.scheme|HTTPS or HTTP scheme.|HTTP|
 |resources.limits.cpu|CPU resource limit|default|

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -120,7 +120,7 @@ spec:
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: {{ if .Values.hotRestart.enabled}} /hazelcast/health/ready {{ else }} {{ .Values.readinessProbe.path }} {{ end }}
+            path: {{ .Values.readinessProbe.path }}
             port: {{ if .Values.readinessProbe.port }}{{ .Values.readinessProbe.port }}{{ else if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
             scheme: {{ .Values.readinessProbe.scheme }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -159,7 +159,7 @@ readinessProbe:
   # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
   failureThreshold: 10
   # url path that will be called to check readiness
-  path: /hazelcast/health/node-state
+  path: /hazelcast/health/ready
   # port that will be used in readiness probe calls
   # port:
   # HTTPS or HTTP scheme

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.5.0
+version: 5.5.1
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.5.2
+version: 5.6.0
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.5.1
+version: 5.5.2
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -95,7 +95,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | readinessProbe.timeoutSeconds | When the probe times out| 1 |
 | readinessProbe.successThreshold | Minimum consecutive successes for the probe to be considered successful after having failed | 1 |
 | readinessProbe.failureThreshold | Minimum consecutive failures for the probe to be considered failed after having succeeded.| 3 |
-| readinessProbe.path | URL path that will be called to check readiness.| /hazelcast/health/node-state|
+| readinessProbe.path | URL path that will be called to check readiness.| /hazelcast/health/ready|
 | readinessProbe.port | Port that will be used in readiness probe calls.| nil |
 | resources.limits.cpu| CPU resource limit | default|
 | resources.limits.memory | Memory resource limit| default|

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -137,7 +137,7 @@ readinessProbe:
   # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
   failureThreshold: 10
   # url path that will be called to check readiness
-  path: /hazelcast/health/node-state
+  path: /hazelcast/health/ready
   # port that will be used in readiness probe calls
   # port:
 


### PR DESCRIPTION
Set the usage of the `/health/ready` endpoint for the `readinessProbe` as a default value for `EE` and `OS` regardless of the `persistence.enabled` status