### PR TITLE
`service.name` configuration is used while setting `hazelcast.serviceName` template

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.5.1
+version: 5.5.2
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/_helpers.tpl
+++ b/stable/hazelcast-enterprise/templates/_helpers.tpl
@@ -46,10 +46,10 @@ Create the name of the service account to use
 Create the name of the service to use
 */}}
 {{- define "hazelcast.serviceName" -}}
-{{- if .Values.service.create -}}
-    {{ template "hazelcast.fullname" .}}
-{{- else -}}
+{{- if .Values.service.name -}}
     {{ default "default" .Values.service.name }}
+{{- else -}}
+    {{ template "hazelcast.fullname" .}}
 {{- end -}}
 {{- end -}}
 

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.5.0
+version: 5.5.1
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -104,7 +104,7 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | podDisruptionBudget.maxUnavailable| Number of max unavailable pods| |
 | podDisruptionBudget.minAvailable| Number of min available pods| |
 | service.create | Enable installing Service| true|
-| service.name | Name of Service, by default generated using the fullname template. To override, two condition need to be met: service.create=false (service must exist before chart deploy) and value of service.name must not be nil | nil |
+| service.name | Name of Service, if not set, the name is generated using the fullname template | nil |
 | service.type | Kubernetes service type (`ClusterIP`, `LoadBalancer`, or `NodePort`) | ClusterIP|
 | service.port | Kubernetes service port| 5701|
 | service.clusterIP| IP of the service, "None" makes the service headless| None|

--- a/stable/hazelcast/templates/_helpers.tpl
+++ b/stable/hazelcast/templates/_helpers.tpl
@@ -46,10 +46,10 @@ Create the name of the service account to use
 Create the name of the service to use
 */}}
 {{- define "hazelcast.serviceName" -}}
-{{- if .Values.service.create -}}
-    {{ template "hazelcast.fullname" .}}
-{{- else -}}
+{{- if .Values.service.name -}}
     {{ default "default" .Values.service.name }}
+{{- else -}}
+    {{ template "hazelcast.fullname" .}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
- Honoring `service.name` defined in the configuration to be used as `hazelcast.serviceName` in both hazelcast and hazelcast-enterprise charts.
- hazelcast-enterprise README correctly documents the purpose of `serivce.name` but hazelcast document does not. Updated the same.
- Bumped up the chart versions.