### PR TITLE
Add subPath and subPathExpr to mancenter persistence

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.6.0
+version: 5.7.0
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/README.md
+++ b/stable/hazelcast-enterprise/README.md
@@ -181,6 +181,8 @@ The following table lists the configurable parameters of the Hazelcast chart and
 |mancenter.persistence.accessModes|Access Modes of the new Persistent Volume Claim|ReadWriteOnce|
 |mancenter.persistence.size|Size of the new Persistent Volume Claim|8Gi|
 |mancenter.persistence.storageClass| Storage class name used for Management Center|nil|
+|mancenter.persistence.subPath| Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).|nil|
+|mancenter.persistence.subPathExpr| Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. |nil|
 |mancenter.service.type|Kubernetes service type (`ClusterIP`, `LoadBalancer`, or `NodePort`)|LoadBalancer|
 |mancenter.service.port|Kubernetes service port|8080|
 |mancenter.service.loadBalancerIP| IP to be used to access management center for `LoadBalancer` service type| nil|

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -107,6 +107,11 @@ spec:
           mountPath: /config
         - name: mancenter-storage
           mountPath: /data
+          {{- if .Values.mancenter.persistence.subPath }}
+          subPath: {{ .Values.mancenter.persistence.subPath }}
+          {{- else if .Values.mancenter.persistence.subPathExpr }}
+          subPathExpr: {{ .Values.mancenter.persistence.subPathExpr }}
+          {{- end }}
         {{- if .Values.mancenter.secretsMountName }}
         - name: mancenter-secrets
           mountPath: /secrets

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -461,6 +461,13 @@ mancenter:
     size: 8Gi
     # storageClass defines the storage class used for Management Center. Read more at: https://kubernetes.io/docs/concepts/storage/storage-classes/
     # storageClass:
+    # subPath Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+    # subPath:
+    # subPathExpr Expanded path within the volume from which the container's volume should be mounted.
+    # Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the
+    # container's environment. Defaults to "" (volume's root).
+    # SubPathExpr and SubPath are mutually exclusive.
+    # subPathExpr:
 
   # Hazelcast Management Center Service properties
   service:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.6.0
+version: 5.7.0
 appVersion: "5.2.0"
 kubeVersion: ">=1.14.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/README.md
+++ b/stable/hazelcast/README.md
@@ -174,6 +174,8 @@ The following table lists the configurable parameters of the Hazelcast chart and
 | mancenter.persistence.accessModes | Access Modes of the new Persistent Volume Claim | ReadWriteOnce|
 | mancenter.persistence.size| Size of the new Persistent Volume Claim | 8Gi |
 | mancenter.persistence.storageClass| Storage class name used for Management Center| nil |
+| mancenter.persistence.subPath| Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).| nil |
+| mancenter.persistence.subPathExpr| Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive. | nil |
 | mancenter.service.type| Kubernetes service type (`ClusterIP`, `LoadBalancer`, or `NodePort`) | LoadBalancer|
 | mancenter.service.port| Kubernetes service port| 8080|
 | mancenter.service.loadBalancerIP| IP to be used to access management center for `LoadBalancer` service type| nil|

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -106,6 +106,11 @@ spec:
           mountPath: /config
         - name: mancenter-storage
           mountPath: /data
+          {{- if .Values.mancenter.persistence.subPath }}
+          subPath: {{ .Values.mancenter.persistence.subPath }}
+          {{- else if .Values.mancenter.persistence.subPathExpr }}
+          subPathExpr: {{ .Values.mancenter.persistence.subPathExpr }}
+          {{- end }}
         {{- if .Values.mancenter.secretsMountName }}
         - name: mancenter-secrets
           mountPath: /secrets

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -416,6 +416,13 @@ mancenter:
     size: 8Gi
     # storageClass defines the storage class used for Management Center. Read more at: https://kubernetes.io/docs/concepts/storage/storage-classes/
     # storageClass:
+    # subPath Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+    # subPath:
+    # subPathExpr Expanded path within the volume from which the container's volume should be mounted.
+    # Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the
+    # container's environment. Defaults to "" (volume's root).
+    # SubPathExpr and SubPath are mutually exclusive.
+    # subPathExpr:
 
   # Hazelcast Management Center Service properties
   service:


### PR DESCRIPTION
Add subPath and subPathExpr to Management Center persistence.

See also https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#volumes-1

Signed-off-by: mgmgwi <guido.wischrop@mgm-tp.com>