### PR TITLE
hazelcast: Add support for extraVolumes

### DIFF
--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -148,6 +148,9 @@ spec:
         - name: hazelcast-external
           mountPath: /data/external
         {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
         env:
         {{- if .Values.hazelcast.licenseKeySecretName }}
         - name: HZ_LICENSEKEY
@@ -232,6 +235,9 @@ spec:
         {{- if .Values.externalVolume }}
         - name: hazelcast-external
 {{ toYaml .Values.externalVolume | indent 10 }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+{{ toYaml . | indent 8 }}
         {{- end }}
   {{- if and (and (eq .Values.persistence.enabled true) (empty .Values.persistence.existingClaim)) (empty .Values.persistence.hostPath) }}
   volumeClaimTemplates:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -587,3 +587,16 @@ test:
 ## Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+
+## Extra Volumes for the pod
+##
+extraVolumes: []
+  # - name: example
+  #   configMap:
+  #     name: example
+
+## Extra Volume Mounts for the Hazelcast container
+#
+extraVolumeMounts: []
+  # - name: example
+  #   mountPath: /example

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -138,6 +138,9 @@ spec:
         - name: hazelcast-external
           mountPath: /data/external
         {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
         env:
         - name: POD_NAME
           valueFrom:
@@ -195,5 +198,8 @@ spec:
       {{- if .Values.externalVolume }}
       - name: hazelcast-external
 {{ toYaml .Values.externalVolume | indent 8 }}
+      {{- end }}
+      {{- with .Values.extraVolumes }}
+{{ toYaml . | indent 6 }}
       {{- end }}
 {{- end }}

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -553,3 +553,16 @@ test:
 ## Array of extra objects to deploy with the release
 ##
 extraDeploy: []
+
+## Extra Volumes for the pod
+##
+extraVolumes: []
+  # - name: example
+  #   configMap:
+  #     name: example
+
+## Extra Volume Mounts for the Hazelcast container
+#
+extraVolumeMounts: []
+  # - name: example
+  #   mountPath: /example


### PR DESCRIPTION
Add possibility to define extra volume mounts. This is sometimes needed to make `/tmp` directory writable because we enforce read only files system with `securityContext.readOnlyRootFilesystem`.

```
extraVolumes:
  - name: tmp
    emptyDir: {}

extraVolumeMounts:
  - name: tmp
    mountPath: /tmp
```