### PR TITLE
[CN-890] Chart update workflow

### DIFF
--- a/.github/workflows/chart-update.yml
+++ b/.github/workflows/chart-update.yml
@@ -1,0 +1,156 @@
+name: Chart Version Update
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  chart-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Old Workflow Run
+        run: |
+          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
+          WORKFLOW_ID=$(gh api repos/${GITHUB_REPOSITORY}/actions/workflows | jq '.workflows[] | select(.["name"] | contains("Chart Version Update")) | .id')
+          RUN_ID=$(gh api repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_ID}/runs --paginate | jq '.workflow_runs[] | select(.["status"] | contains("completed")) | select(.head_commit.message) | .id')
+          if [[ -n "$RUN_ID" ]]; then
+            gh api repos/${GITHUB_REPOSITORY}/actions/runs/$RUN_ID -X DELETE >/dev/null
+          fi
+
+      - name: Install yq
+        uses: mikefarah/yq@v4.34.1
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Update Charts
+        working-directory: stable
+        id: update_version
+        run: |
+          HZ_REPO="hazelcast/hazelcast"
+          MC_REPO="hazelcast/management-center"
+          paths=("hazelcast" "hazelcast-enterprise")
+
+          # Function to extract a specific field value from a YAML file
+          extract_version() {
+            local FIELD="$1"
+            local FILENAME="$2"
+            VERSION=$(yq eval $FIELD "$FILENAME")
+            echo "$VERSION"
+          }
+
+          # Function to get the latest Git tag from the specified repository
+          get_latest_tag() {
+            echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
+            local LATEST_TAG=$(gh api repos/$1/git/matching-refs/tags --jq '.[].ref | select(test("^refs/tags/v[0-9]+\\.[0-9]+\\.[0-9]+$")) | sub("^refs/tags/v"; "")' | sort -V | tail -n1)
+            echo "$LATEST_TAG"
+          }
+
+          # Function to extract major, minor, and patch parts from a version string
+          extract_version_parts() {
+            local VERSION="${1#v}"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+            echo "$MAJOR,$MINOR,$PATCH"
+          }
+
+          # Function to increment a version part
+          increment_version() {
+            local PART_VALUE=$1
+            ((PART_VALUE++))
+            echo "$PART_VALUE"
+          }
+
+          # Function to update the chart version based on the latest tag and app version
+          update_version() {
+            local HZ_LATEST_TAG="$1"
+            local APP_VERSION="$2"
+            local CHART_VERSION="$3"
+
+            # Extract version parts from the latest tag, app version, and chart version
+            IFS=',' read -r HZ_MAJOR HZ_MINOR HZ_PATCH <<< "$(extract_version_parts "$HZ_LATEST_TAG")"
+            IFS=',' read -r APP_MAJOR APP_MINOR APP_PATCH <<< "$(extract_version_parts "$APP_VERSION")"
+            IFS=',' read -r CHART_MAJOR CHART_MINOR CHART_PATCH <<< "$(extract_version_parts "$CHART_VERSION")"
+
+            # Compare the version parts and update the chart version if necessary
+            if [[ $HZ_MAJOR != $APP_MAJOR ]]; then
+              CHART_MINOR=0
+              CHART_PATCH=0
+              CHART_MAJOR=$(increment_version "$CHART_MAJOR")
+            elif [[ $HZ_MINOR != $APP_MINOR ]]; then
+              CHART_MINOR=$(increment_version "$CHART_MINOR")
+              CHART_PATCH=0
+            elif [[ $HZ_PATCH != $APP_PATCH ]]; then
+              CHART_PATCH=$(increment_version "$CHART_PATCH")
+            fi
+              echo "$CHART_MAJOR.$CHART_MINOR.$CHART_PATCH"
+          }
+
+          # Function to check the version and update the chart files if necessary
+          check_version_and_update() {
+              HZ_LATEST_TAG=$(get_latest_tag "$HZ_REPO")
+              MC_LATEST_TAG=$(get_latest_tag "$MC_REPO")
+            for path in "${paths[@]}"; do
+              APP_VERSION=$(extract_version .appVersion "$path/Chart.yaml")
+              CHART_VERSION=$(extract_version .version "$path/Chart.yaml")
+              MC_VERSION=$(extract_version .mancenter.image.tag "$path/values.yaml")
+          
+              echo "HZ_LATEST_TAG=${HZ_LATEST_TAG}" >> $GITHUB_ENV
+              echo "MC_LATEST_TAG=${MC_LATEST_TAG}" >> $GITHUB_ENV
+          
+              if [[ $HZ_LATEST_TAG != $APP_VERSION ]]; then
+                NEW_CHART_VERSION=$(update_version "$HZ_LATEST_TAG" "$APP_VERSION" "$CHART_VERSION")
+                sed -i -E -e 's/(version: ).*/\1'"$NEW_CHART_VERSION"'/' -e 's/(appVersion: ).*/\1'\"$HZ_LATEST_TAG\"'/' "$path/Chart.yaml"
+                awk '/^image:/ {p=1} p && /tag:/ {sub(/tag:.*/, "tag: \"'$HZ_LATEST_TAG'\""); p=0} 1' "$path/values.yaml" > temp.yaml && mv temp.yaml "$path/values.yaml"
+                echo "HZ_UPDATED=true" >> $GITHUB_OUTPUT
+                echo "HZ_UPDATED=true" >> $GITHUB_ENV
+              fi
+          
+              if [[ $MC_LATEST_TAG != $MC_VERSION ]]; then
+                awk '/^mancenter:/ {p=1} p && /tag:/ {sub(/tag:.*/, "tag: \"'$MC_LATEST_TAG'\""); p=0} 1' "$path/values.yaml" > temp.yaml && mv temp.yaml "$path/values.yaml"
+                echo "MC_UPDATED=true" >> $GITHUB_OUTPUT
+                echo "MC_UPDATED=true" >> $GITHUB_ENV
+              fi
+              if [[ $HZ_LATEST_TAG == $APP_VERSION && $MC_LATEST_TAG == $MC_VERSION ]]; then
+                echo "No new tag found for HZ. The latest is: $hz_latest_tag"
+                echo "No new tag found for MC. The latest is: $mc_latest_tag"
+              fi
+            done
+          }
+          check_version_and_update
+
+      - name: Generate Branch Name and PR Title
+        id: title
+        if: (steps.update_version.outputs.HZ_UPDATED == 'true' || steps.update_version.outputs.MC_UPDATED == 'true')
+        run: |
+          if [[ $HZ_UPDATED == 'true' && $MC_UPDATED != 'true' ]]; then
+             TITLE="Upgrade Hazelcast version to ${{ env.HZ_LATEST_TAG }}"
+             BRANCH="update-hz-to-${{ env.HZ_LATEST_TAG }}"
+          elif [[ $HZ_UPDATED != 'true' && $MC_UPDATED == 'true' ]]; then
+             TITLE="Upgrade MC version to ${{ env.MC_LATEST_TAG }}"
+             BRANCH="update-mc-to-${{ env.MC_LATEST_TAG }}"
+          else
+             TITLE="Upgrade Hazelcast and MC version to ${{ env.HZ_LATEST_TAG }} and ${{ env.MC_LATEST_TAG }}"
+             BRANCH="update-hz-mc-to-${{ env.HZ_LATEST_TAG }}-${{ env.MC_LATEST_TAG }}"
+          fi
+            echo "TITLE=$TITLE" >> $GITHUB_ENV
+            echo "BRANCH=$BRANCH" >> $GITHUB_ENV
+
+      - name: Commit and Push Changes
+        if: (steps.update_version.outputs.HZ_UPDATED == 'true' || steps.update_version.outputs.MC_UPDATED == 'true')
+        run: |
+          git config user.email "devopshelm@hazelcast.com"
+          git config user.name "devOpsHelm"
+          BRANCH_NAME=update-to-${{ env.HZ_LATEST_TAG }}
+          git checkout -b ${{ env.BRANCH }}
+          git add .
+          git commit --signoff -m "${{ env.TITLE }}"
+          git push -u origin ${{ env.BRANCH }}
+
+      - name: Create PR to Main Branch
+        if: (steps.update_version.outputs.HZ_UPDATED == 'true' || steps.update_version.outputs.MC_UPDATED == 'true')
+        run: |
+          echo ${{ secrets.GH_TOKEN }} | gh auth login --with-token
+          gh pr create --fill \
+          --label "safe-to-test" \
+          --reviewer "hazelcast/cloud-native"


### PR DESCRIPTION
This workflow will run in the midnight and will check the latest HZ and MC tags. If it's different from the version in charts or values files for EE and OS then it will change the version, create PR. 
Also in the beginning the workflow will always clean the previous run.