### PR TITLE
Make test optional

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.9.0
+version: 5.9.1
 appVersion: "5.3.1"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hazelcast.enabled }}
+{{- if and .Values.hazelcast.enabled .Values.test.hazelcast }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mancenter.enabled }}
+{{- if and .Values.mancenter.enabled .Values.test.mancenter }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -578,6 +578,8 @@ externalAccess:
     # Annotations for the services that will be created.
     annotations: {}
 test:
+  hazelcast: true
+  mancenter: true
   ## Hazelcast chart test hook image version
   image:
     # repository is the chart test hook image name

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -578,7 +578,9 @@ externalAccess:
     # Annotations for the services that will be created.
     annotations: {}
 test:
+  # whether to deploy test apps to validate cluster
   hazelcast: true
+  # whether to deploy test apps to validate management center
   mancenter: true
   ## Hazelcast chart test hook image version
   image:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.0
+version: 5.8.1
 appVersion: "5.3.1"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast/templates/tests/test-hazelcast.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hazelcast.enabled }}
+{{- if and .Values.hazelcast.enabled .Values.test.hazelcast }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast/templates/tests/test-management-center.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mancenter.enabled }}
+{{- if and .Values.mancenter.enabled  .Values.test.mancenter }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -534,6 +534,8 @@ externalAccess:
     annotations: {}
 
 test:
+  hazelcast: true
+  mancenter: true
   ## Hazelcast chart test hook image version
   image:
     # repository is the chart test hook image name

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -534,7 +534,9 @@ externalAccess:
     annotations: {}
 
 test:
+  # whether to deploy test apps to validate cluster
   hazelcast: true
+  # whether to deploy test apps to validate management center
   mancenter: true
   ## Hazelcast chart test hook image version
   image:


### PR DESCRIPTION
Deployment of test applications should be elective and left to user to decide.

This PR allows possibility to skip test application deployment. For backward compatibility default behaviour is to deploy test apps.