### PR TITLE
Add startup probes

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.9.0
+version: 5.9.1
 appVersion: "5.3.1"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -102,6 +102,17 @@ spec:
           successThreshold: {{ .Values.mancenter.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.mancenter.readinessProbe.failureThreshold }}
         {{- end }}
+        {{- if .Values.mancenter.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{ end }}/health
+            port: 8081
+          initialDelaySeconds: {{ .Values.mancenter.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.mancenter.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.mancenter.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.mancenter.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.mancenter.startupProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /config
@@ -234,7 +245,7 @@ spec:
           value: "{{ $clusterConfigCommand }}"
         {{- end }}
         - name: JAVA_OPTS
-          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
+          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled .Values.mancenter.startupProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- with .Values.mancenter.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}        

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -107,6 +107,7 @@ spec:
           httpGet:
             path: {{ if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{ end }}/health
             port: 8081
+            scheme: HTTP
           initialDelaySeconds: {{ .Values.mancenter.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.mancenter.startupProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.mancenter.startupProbe.timeoutSeconds }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -129,6 +129,18 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
+        {{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.startupProbe.path }}
+            port: {{ if .Values.startupProbe.port }}{{ .Values.startupProbe.port }}{{ else if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
+            scheme: {{ .Values.startupProbe.scheme }}
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: hazelcast-storage
           mountPath: /data/hazelcast

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -165,6 +165,27 @@ readinessProbe:
   # HTTPS or HTTP scheme
   scheme: HTTP
 
+# Hazelcast Startup probe
+startupProbe:
+  # enabled is a flag to used to enable startup probe
+  enabled: false
+  # initialDelaySeconds is a delay before startup probe is initiated
+  initialDelaySeconds: 30
+  # periodSeconds decides how often to perform the probe
+  periodSeconds: 10
+  # timeoutSeconds decides when the probe times out
+  timeoutSeconds: 10
+  # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
+  successThreshold: 1
+  # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
+  failureThreshold: 10
+  # url path that will be called to check startup
+  path: /hazelcast/health/node-state
+  # port that will be used in startup probe calls
+  # port:
+  # HTTPS or HTTP scheme
+  scheme: HTTP
+
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/
 #
@@ -515,6 +536,20 @@ mancenter:
     periodSeconds: 10
     # timeoutSeconds decides when the probe times out
     timeoutSeconds: 1
+    # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
+    failureThreshold: 3
+  # Hazelcast Management Center Startup probe
+  startupProbe:
+    # enabled is a flag to used to enable startup probe
+    enabled: false
+    # initialDelaySeconds is a delay before startup probe is initiated
+    initialDelaySeconds: 30
+    # periodSeconds decides how often to perform the probe
+    periodSeconds: 10
+    # timeoutSeconds decides when the probe times out
+    timeoutSeconds: 5
     # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
     successThreshold: 1
     # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.0
+version: 5.8.1
 appVersion: "5.3.1"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -101,6 +101,17 @@ spec:
           successThreshold: {{ .Values.mancenter.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.mancenter.readinessProbe.failureThreshold }}
         {{- end }}
+        {{- if .Values.mancenter.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{ end }}/health
+            port: 8081
+          initialDelaySeconds: {{ .Values.mancenter.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.mancenter.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.mancenter.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.mancenter.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.mancenter.startupProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /config
@@ -166,7 +177,7 @@ spec:
           value: "{{ $clusterConfigCommand }}"
         {{- end }}
         - name: JAVA_OPTS
-          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
+          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled .Values.mancenter.startupProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- with .Values.mancenter.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}        

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -127,6 +127,17 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
+        {{- if .Values.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: {{ .Values.startupProbe.path }}
+            port: {{ if .Values.startupProbe.port }}{{ .Values.startupProbe.port }}{{ else if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
+          initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+          successThreshold: {{ .Values.startupProbe.successThreshold }}
+          failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+        {{- end }}
         volumeMounts:
         - name: hazelcast-storage
           mountPath: /data/hazelcast

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -141,6 +141,25 @@ readinessProbe:
   # port that will be used in readiness probe calls
   # port:
 
+# Hazelcast Startup probe
+startupProbe:
+  # enabled is a flag to used to enable startup probe
+  enabled: false
+  # initialDelaySeconds is a delay before startup probe is initiated
+  initialDelaySeconds: 30
+  # periodSeconds decides how often to perform the probe
+  periodSeconds: 10
+  # timeoutSeconds decides when the probe times out
+  timeoutSeconds: 10
+  # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
+  successThreshold: 1
+  # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
+  failureThreshold: 10
+  # url path that will be called to check startup
+  path: /hazelcast/health/node-state
+  # port that will be used in startup probe calls
+  # port:
+
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/
 #
@@ -470,6 +489,20 @@ mancenter:
     periodSeconds: 10
     # timeoutSeconds decides when the probe times out
     timeoutSeconds: 1
+    # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
+    failureThreshold: 3
+  # Hazelcast Management Center Startup probe
+  startupProbe:
+    # enabled is a flag to used to enable startup probe
+    enabled: false
+    # initialDelaySeconds is a delay before startup probe is initiated
+    initialDelaySeconds: 30
+    # periodSeconds decides how often to perform the probe
+    periodSeconds: 10
+    # timeoutSeconds decides when the probe times out
+    timeoutSeconds: 5
     # successThreshold is the minimum consecutive successes for the probe to be considered successful after having failed
     successThreshold: 1
     # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded


### PR DESCRIPTION
This PR adds startup probes for Hazelcast and Management Center. Default is marked as false to avoid being a disruptive change.