### PR TITLE
Enhance env variable options

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.9.0
+version: 5.9.1
 appVersion: "5.3.1"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -237,7 +237,24 @@ spec:
           value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- with .Values.mancenter.env }}
           {{- toYaml . | nindent 8 }}
-        {{- end }}        
+        {{- end }}
+        {{- range $key, $val := .Values.mancenter.envMap }}
+        - name: {{ $key }}
+          value: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.mancenter.envFromField }}
+        - name: {{ $key }}
+          valueFrom:
+            fieldRef:
+              fieldPath: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.mancenter.envFromSecrets }}
+        - name:
+          valueFrom:
+            secretKeyRef:
+              key: {{ $val.secretKey }}
+              name: {{ $val.secretName }}
+        {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -240,7 +240,7 @@ spec:
         {{- end }}
         {{- range $key, $val := .Values.mancenter.envMap }}
         - name: {{ $key }}
-          value: {{ $val }}
+          value: {{ $val | quote }}
         {{- end }}
         {{- range $key, $val := .Values.mancenter.envFromField }}
         - name: {{ $key }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
         {{- end }}
         {{- range $key, $val := .Values.envMap }}
         - name: {{ $key }}
-          value: {{ $val }}
+          value: {{ $val | quote }}
         {{- end }}
         {{- range $key, $val := .Values.envFromField }}
         - name: {{ $key }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -163,10 +163,6 @@ spec:
         - name: CLASSPATH
           value: "/data/custom:/data/custom/*"
         {{- end }}
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         {{- if .Values.metrics.enabled }}
         - name: PROMETHEUS_PORT
           value: "{{ .Values.metrics.service.port }}"
@@ -179,6 +175,23 @@ spec:
         {{- if .Values.hazelcast.loggingLevel }}
         - name: LOGGING_LEVEL
           value: {{ .Values.hazelcast.loggingLevel }}
+        {{- end }}
+        {{- range $key, $val := .Values.envMap }}
+        - name: {{ $key }}
+          value: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.envFromField }}
+        - name: {{ $key }}
+          valueFrom:
+            fieldRef:
+              fieldPath: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.envFromSecrets }}
+        - name:
+          valueFrom:
+            secretKeyRef:
+              key: {{ $val.secretKey }}
+              name: {{ $val.secretName }}
         {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -334,6 +334,17 @@ env: []
   #     secretKeyRef:
   #       key: db-username
   #       name: servicename-db-creds
+# Additional environment variables as key-value pairs.
+# Helps in aggregating environment variables sourced from multiple values file
+envMap: {}
+# Additional environment variables sourced from secrets as key-value (where value is object type)
+envFromSecrets: {}
+  # someSecret:
+  #   secretKey: key
+  #   secretName: name
+# Additional environment variables sourced from fields. Provided as key-value pairs
+envFromField:
+  POD_NAME: metadata.name
 
 # Hazelcast Management Center application properties
 mancenter:
@@ -528,12 +539,22 @@ mancenter:
   # secretsMountName:
 
   # Additional Environment variables
-  env: [] 
+  env: []
     # - name: DB_USERNAME
     #   valueFrom:
     #     secretKeyRef:
     #       key: db-username
     #       name: servicename-db-creds
+  # Additional environment variables as key-value pairs.
+  # Helps in aggregating environment variables sourced from multiple values file
+  envMap: {}
+  # Additional environment variables sourced from secrets as key-value (where value is object type)
+  envFromSecrets: {}
+    # someSecret:
+    #   secretKey: key
+    #   secretName: name
+  # Additional environment variables sourced from fields. Provided as key-value pairs
+  envFromField: {}
 
 ## External Access to Hazelcast nodes configuration
 ##

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.0
+version: 5.8.1
 appVersion: "5.3.1"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -172,7 +172,7 @@ spec:
         {{- end }}
         {{- range $key, $val := .Values.mancenter.envMap }}
         - name: {{ $key }}
-          value: {{ $val }}
+          value: {{ $val | quote }}
         {{- end }}
         {{- range $key, $val := .Values.mancenter.envFromField }}
         - name: {{ $key }}

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -169,7 +169,24 @@ spec:
           value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- with .Values.mancenter.env }}
           {{- toYaml . | nindent 8 }}
-        {{- end }}        
+        {{- end }}
+        {{- range $key, $val := .Values.mancenter.envMap }}
+        - name: {{ $key }}
+          value: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.mancenter.envFromField }}
+        - name: {{ $key }}
+          valueFrom:
+            fieldRef:
+              fieldPath: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.mancenter.envFromSecrets }}
+        - name:
+          valueFrom:
+            secretKeyRef:
+              key: {{ $val.secretKey }}
+              name: {{ $val.secretName }}
+        {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:
           runAsNonRoot: {{ if eq (int .Values.securityContext.runAsUser) 0 }}false{{ else }}true{{ end }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -158,7 +158,7 @@ spec:
         {{- end }}
         {{- range $key, $val := .Values.envMap }}
         - name: {{ $key }}
-          value: {{ $val }}
+          value: {{ $val | quote }}
         {{- end }}
         {{- range $key, $val := .Values.envFromField }}
         - name: {{ $key }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -139,10 +139,6 @@ spec:
           mountPath: /data/external
         {{- end }}
         env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
         {{- if .Values.customVolume }}
         - name: CLASSPATH
           value: "/data/custom:/data/custom/*"
@@ -159,6 +155,23 @@ spec:
         {{- if .Values.hazelcast.loggingLevel }}
         - name: LOGGING_LEVEL
           value: {{ .Values.hazelcast.loggingLevel }}
+        {{- end }}
+        {{- range $key, $val := .Values.envMap }}
+        - name: {{ $key }}
+          value: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.envFromField }}
+        - name: {{ $key }}
+          valueFrom:
+            fieldRef:
+              fieldPath: {{ $val }}
+        {{- end }}
+        {{- range $key, $val := .Values.envFromSecrets }}
+        - name:
+          valueFrom:
+            secretKeyRef:
+              key: {{ $val.secretKey }}
+              name: {{ $val.secretName }}
         {{- end }}
         {{- if .Values.securityContext.enabled }}
         securityContext:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -286,6 +286,17 @@ env: []
   #     secretKeyRef:
   #       key: db-username
   #       name: servicename-db-creds
+# Additional environment variables as key-value pairs.
+# Helps in aggregating environment variables sourced from multiple values file
+envMap: {}
+# Additional environment variables sourced from secrets as key-value (where value is object type)
+envFromSecrets: {}
+  # someSecret:
+  #   secretKey: key
+  #   secretName: name
+# Additional environment variables sourced from fields. Provided as key-value pairs
+envFromField:
+  POD_NAME: metadata.name
 
 # Hazelcast Jet Engine
 jet:
@@ -489,6 +500,16 @@ mancenter:
     #     secretKeyRef:
     #       key: db-username
     #       name: servicename-db-creds
+  # Additional environment variables as key-value pairs.
+  # Helps in aggregating environment variables sourced from multiple values file
+  envMap: {}
+  # Additional environment variables sourced from secrets as key-value (where value is object type)
+  envFromSecrets: {}
+    # someSecret:
+    #   secretKey: key
+    #   secretName: name
+  # Additional environment variables sourced from fields. Provided as key-value pairs
+  envFromField: {}
 
 ## External Access to Hazelcast nodes configuration
 ##


### PR DESCRIPTION
It should be possible to aggregate environment variables from multiple `values.yaml` files. Describing the `env` variables as array object limits the flexibility and leads to lot of duplicated code (or config) which can be avoided if we use `map` objects for setting environment variables. This PR adds the options of setting environment variables from
- simple key-value pairs
- key-value pairs for fetching fields from field reference
- key-object pairs for fetching fields from secrets