### PR TITLE
Remove chart-name from volumeClaimTemplate's label section for working chart upgrades

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.9.2
+version: 5.10.0
 appVersion: "5.3.1"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -227,7 +227,6 @@ spec:
       name: mancenter-storage
       labels:
         app.kubernetes.io/name: {{ template "mancenter.name" . }}
-        helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     spec:

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -239,7 +239,6 @@ spec:
       name: persistence
       labels:
         app.kubernetes.io/name: {{ template "hazelcast.name" . }}
-        helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     spec:


### PR DESCRIPTION
When user enables persistence/hotRestart at values.yaml as I mentioned above, the chart creates required PVs via volumeClaimTemplate. Unfortunately, we are using dynamic labels at volumeClaimTemplate section at StatefulSet yaml:
https://github.com/hazelcast/charts/blob/master/stable/hazelcast-enterprise/templates/statefulset.yaml#L242
```
  volumeClaimTemplates:
  - metadata:
      name: hot-restart-persistence
      labels:
        app.kubernetes.io/name: hazelcast-enterprise
        --> helm.sh/chart: hazelcast-enterprise-3.10.3 <--
        app.kubernetes.io/instance: "hz"
        app.kubernetes.io/managed-by: "Helm"
```

```
  volumeClaimTemplates:
  - metadata:
      name: hot-restart-persistence
      labels:
        app.kubernetes.io/name: hazelcast-enterprise
        --> helm.sh/chart: hazelcast-enterprise-5.0.0 <--
        app.kubernetes.io/instance: "hz"
        app.kubernetes.io/managed-by: "Helm"
````

Due to dynamic labeling, we are hitting the issue below:
https://github.com/helm/charts/issues/7803
```
Error: UPGRADE FAILED: cannot patch "hz-hazelcast-enterprise" with kind StatefulSet: StatefulSet.apps "hz-hazelcast-enterprise" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'ordinals', 'template', 'updateStrategy', 'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are forbidden
````
This label changes during `helm upgrade` prevents any future upgrade of existing release.

To provide a successful upgrade from 4.2.x to 5.0.x, we need to release additional new charts:
- [x] `3.11.0` from[ 4.2.z](https://github.com/hazelcast/charts/tree/4.2.z) branch --> https://github.com/hazelcast/charts/pull/368

- [ ] `5.3.9` from https://github.com/hazelcast/charts/commit/86adb05