### PR TITLE
Ingress can not be enabled without Management Center

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.10.4
+version: 5.10.5
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mancenter.ingress.enabled -}}
+{{- if and .Values.mancenter.enabled .Values.mancenter.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.5
+version: 5.8.6
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast/templates/mancenter-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mancenter.ingress.enabled -}}
+{{- if and .Values.mancenter.enabled .Values.mancenter.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
```
helm install hz hazelcast/hazelcast --set mancenter.enabled=false --set mancenter.ingress.enabled=true
```
Charts should not create Ingress when the user runs the command above.