### PR TITLE
Allow further config of Management Center

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.10.5
+version: 5.10.6
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.10.6
+version: 5.10.7
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -232,7 +232,7 @@ spec:
     spec:
       accessModes:
       {{- range .Values.mancenter.persistence.accessModes }}
-      - {{ . | quote }}
+        - {{ . | quote }}
       {{- end }}
       {{- if .Values.mancenter.persistence.storageClass }}
       {{- if (eq "-" .Values.mancenter.persistence.storageClass) }}
@@ -244,5 +244,5 @@ spec:
       resources:
         requests:
           storage: {{ .Values.mancenter.persistence.size | quote }}
-      {{- end }}
+  {{- end -}}
 {{- end -}}

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -164,19 +164,33 @@ spec:
         - name: MC_LICENSE_KEY
           value: {{ .Values.hazelcast.licenseKey }}
         {{- end }}
+        {{- $securityResetCommand := "" }}
+        {{- $securityConfigureCommand := "" }}
+        {{- with .Values.mancenter.security}}
+          {{- if or .activeDirectory.enabled .devMode.enabled}}
+            {{- $securityResetCommand = "./bin/mc-conf.sh security reset --lenient=true -H /data; " }}
+          {{- end }}
+          {{- if .activeDirectory.enabled }}
+            {{- with .activeDirectory }}
+              {{- $adminGroups := join ";" .adminGroups }}
+              {{- $userGroups := join ";" .userGroups }} 
+              {{- $readOnlyGroups := join ";" .readOnlyGroups }}
+              {{- $metricOnlyGroups := join ";" .metricOnlyGroups }}
+              {{- $nestedGroups := ternary "--nested-group-search" "" .nestedGroupSearch }}
+              {{- $securityConfigureCommand = printf "./bin/mc-conf.sh active-directory configure --home=/data --lenient=true --url='%s' --domain='%s' --user-search-filter='%s' --admin-groups='%s' --read-write-groups='%s' --read-only-groups='%s' --metrics-only-groups='%s' %s --verbose; " .url .domain .userSearchFilter  $adminGroups $userGroups $readOnlyGroups $metricOnlyGroups $nestedGroups }}
+            {{- end }}
+          {{- else if or $.Values.mancenter.devMode.enabled .devMode.enabled }}
+            {{- $securityConfigureCommand = "./bin/mc-conf.sh dev-mode configure; " }}
+          {{- end }}
+        {{- end }}
         {{- $clusterConfigCommand := "" }}
         {{- if .Values.mancenter.clusterConfig.create }}
         {{- $clusterConfigCommand = "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; " }}
         {{- end }}
-        {{- if .Values.mancenter.devMode.enabled }}
         - name: MC_INIT_CMD
-          value: "{{ $clusterConfigCommand }}./bin/mc-conf.sh dev-mode configure"
-        {{- else if .Values.mancenter.clusterConfig.create }}
-        - name: MC_INIT_CMD
-          value: "{{ $clusterConfigCommand }}"
-        {{- end }}
+          value: "{{ $securityResetCommand }}{{ $securityConfigureCommand }}{{ $clusterConfigCommand }}{{ $securityResetCommand }}{{ $securityConfigureCommand }}"
         - name: JAVA_OPTS
-          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
+          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} {{ if $securityResetCommand }} -Dhazelcast.mc.lock.skip=true {{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- with .Values.mancenter.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}        

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -67,6 +67,10 @@ spec:
       topologySpreadConstraints:
 {{ toYaml .Values.mancenter.topologySpreadConstraints | indent 8 }}
       {{- end }}
+      {{- if .Values.mancenter.initContainers }}
+      initContainers:
+{{ toYaml .Values.mancenter.initContainers | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "mancenter.fullname" . }}
         {{- if empty .Values.mancenter.image.tag }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -159,14 +159,14 @@ spec:
         - name: HZ_LICENSEKEY
           value: {{ .Values.hazelcast.licenseKey }}
           {{- end }}
-        {{- if .Values.customVolume }}
-        - name: CLASSPATH
-          value: "/data/custom:/data/custom/*"
-        {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- if .Values.customVolume }}
+        - name: CLASSPATH
+          value: "/data/custom:/data/custom/*"
+        {{- end }}
         {{- if .Values.metrics.enabled }}
         - name: PROMETHEUS_PORT
           value: "{{ .Values.metrics.service.port }}"
@@ -216,7 +216,7 @@ spec:
         {{- if .Values.customVolume }}
         - name: hazelcast-custom
 {{ toYaml .Values.customVolume | indent 10 }}
-            {{- end }}
+        {{- end }}
         {{- if .Values.persistence.enabled }}
         {{- if .Values.persistence.hostPath }}
         - name: persistence

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -343,7 +343,6 @@ mancenter:
     tag: "5.3.2"
     # digest is the Hazelcast Management Center image digest that will be used only if the tag is empty
     digest: ""
-    #
     # pullPolicy is the Docker image pull policy
     # It's recommended to change this to 'Always' if the image tag is 'latest'
     # ref: http://kubernetes.io/docs/user-guide/images/#updating-images
@@ -391,7 +390,6 @@ mancenter:
 
   # adminCredentialsSecretName is Kubernetes Secret Name for admin credentials. Secret has to contain `username` and `password` literals. please check Management Center documentation for password requirements
   # adminCredentialsSecretName:
-
 
   # existingConfigMap defines a ConfigMap which contains Hazelcast Client configuration file(s) that are used instead of hazelcast-client.yaml configuration below
   # existingConfigMap:
@@ -478,7 +476,7 @@ mancenter:
     labels: {}
     #  key: value
     # ClusterIP of the service
-    clusterIP: 
+    clusterIP:
     # loadBalancerIP statically set IP or set empty to use dynamic IP allocation
     loadBalancerIP:
 
@@ -516,13 +514,13 @@ mancenter:
 
   # Cluster config creation will create the connection to the Hazelcast cluster based on the yaml.hazelcast-client
   clusterConfig:
+    # create is a flag used to enable cluster config creation
     create: true
-
   # secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
   # secretsMountName:
 
   # Additional Environment variables
-  env: [] 
+  env: []
     # - name: DB_USERNAME
     #   valueFrom:
     #     secretKeyRef:
@@ -566,11 +564,12 @@ externalAccess:
     #
     nodePorts: []
 
-    # Labels for the services that will be created.
+    ## Labels for the services that will be created.
     labels: {}
 
     # Annotations for the services that will be created.
     annotations: {}
+
 test:
   ## Hazelcast chart test hook image version
   image:
@@ -592,6 +591,17 @@ test:
     runAsUser: 65534
     # runAsGroup is the primary group ID used to run all processes within any container of the pod
     runAsGroup: 65534
+
+  # Configure resource requests and limits
+  # ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  #
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 100m
+  #   limits:
+  #     memory: 1024Mi
+  #     cpu: 200m
 
 ## Array of extra objects to deploy with the release
 ##

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -333,6 +333,7 @@ env: []
 mancenter:
   # enabled is a flag to enable Management Center application
   enabled: true
+
   ## Hazelcast Management Center image version
   ## ref: https://hub.docker.com/r/hazelcast/management-center/tags/
   ##
@@ -353,6 +354,12 @@ mancenter:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     # pullSecrets:
     # - myRegistryKeySecretName
+
+  # Init containers for Management Center
+  initContainers: []
+  #  - name: init-myservice
+  #    image: busybox:1.28
+  #    command: ['sh', '-c', "sleep 2"]
 
   # ingress configuration for mancenter
   ingress:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -354,11 +354,6 @@ mancenter:
     # pullSecrets:
     # - myRegistryKeySecretName
 
-  # Dev mode is for the Hazelcast clusters running on your local for development
-  # or evaluation purposes and it provides quick access to the Management Center without requiring any security credentials
-  devMode:
-    enabled: false
-
   # ingress configuration for mancenter
   ingress:
     enabled: false
@@ -388,8 +383,34 @@ mancenter:
   # licenseKeySecretName is the name of the secret where the Hazelcast Management Center License Key is stored (can be used instead of licenseKey)
   # licenseKeySecretName:
 
+  # Dev mode is for the Hazelcast clusters running on your local for development or evaluation purposes and it provides quick access to the Management Center without requiring any security credentials
+  # Deprected in favor of the `security` config block.
+  # This is mutually exclusive with adminCredentialsSecretName
+  devMode:
+    enabled: false
+
   # adminCredentialsSecretName is Kubernetes Secret Name for admin credentials. Secret has to contain `username` and `password` literals. please check Management Center documentation for password requirements
+  # If this is set it will conflict with devMode or security.activeDirectory.enabled == true
   # adminCredentialsSecretName:
+
+  security:
+    # The follow options are mutually exclusive
+    devMode:
+      enabled: false
+    activeDirectory:
+      enabled: false
+      url: ldap://localhost:10389
+      domain: example.com
+      userSearchFilter: "(&(objectClass=user)(userPrincipalName={0}))"
+      nestedGroupSearch: true
+      adminGroups: #[]
+        - HazelcastMCAdmin
+      userGroups: #[]
+        - HazelcastMCUser
+      readOnlyGroups: #[]
+        - HazelcastMCReadonlyUser
+      metricOnlyGroups: #[]
+        - HazelcastMCMetricsOnlyUser
 
   # existingConfigMap defines a ConfigMap which contains Hazelcast Client configuration file(s) that are used instead of hazelcast-client.yaml configuration below
   # existingConfigMap:
@@ -401,6 +422,10 @@ mancenter:
           enabled: true
           service-name: ${serviceName}
           namespace: ${namespace}
+  # Cluster config creation will create the connection to the Hazelcast cluster based on the yaml.hazelcast-client
+  clusterConfig:
+    # create is a flag used to enable cluster config creation
+    create: true
 
   # annotations is an array of metadata for Management Center Statefulset
   annotations: {}
@@ -512,10 +537,6 @@ mancenter:
     # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
     failureThreshold: 3
 
-  # Cluster config creation will create the connection to the Hazelcast cluster based on the yaml.hazelcast-client
-  clusterConfig:
-    # create is a flag used to enable cluster config creation
-    create: true
   # secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
   # secretsMountName:
 

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.7
+version: 5.8.8
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.6
+version: 5.8.7
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -164,19 +164,33 @@ spec:
         - name: MC_LICENSE_KEY
           value: {{ .Values.hazelcast.licenseKey }}
         {{- end }}
+        {{- $securityResetCommand := "" }}
+        {{- $securityConfigureCommand := "" }}
+        {{- with .Values.mancenter.security}}
+          {{- if or .activeDirectory.enabled .devMode.enabled}}
+            {{- $securityResetCommand = "./bin/mc-conf.sh security reset --lenient=true -H /data; " }}
+          {{- end }}
+          {{- if .activeDirectory.enabled }}
+            {{- with .activeDirectory }}
+              {{- $adminGroups := join ";" .adminGroups }}
+              {{- $userGroups := join ";" .userGroups }} 
+              {{- $readOnlyGroups := join ";" .readOnlyGroups }}
+              {{- $metricOnlyGroups := join ";" .metricOnlyGroups }}
+              {{- $nestedGroups := ternary "--nested-group-search" "" .nestedGroupSearch }}
+              {{- $securityConfigureCommand = printf "./bin/mc-conf.sh active-directory configure --home=/data --lenient=true --url='%s' --domain='%s' --user-search-filter='%s' --admin-groups='%s' --read-write-groups='%s' --read-only-groups='%s' --metrics-only-groups='%s' %s --verbose; " .url .domain .userSearchFilter  $adminGroups $userGroups $readOnlyGroups $metricOnlyGroups $nestedGroups }}
+            {{- end }}
+          {{- else if or $.Values.mancenter.devMode.enabled .devMode.enabled }}
+            {{- $securityConfigureCommand = "./bin/mc-conf.sh dev-mode configure; " }}
+          {{- end }}
+        {{- end }}
         {{- $clusterConfigCommand := "" }}
         {{- if .Values.mancenter.clusterConfig.create }}
         {{- $clusterConfigCommand = "./bin/mc-conf.sh cluster add --lenient=true -H /data -cc /config/hazelcast-client.yaml; " }}
         {{- end }}
-        {{- if .Values.mancenter.devMode.enabled }}
         - name: MC_INIT_CMD
-          value: "{{ $clusterConfigCommand }}./bin/mc-conf.sh dev-mode configure"
-        {{- else if .Values.mancenter.clusterConfig.create }}
-        - name: MC_INIT_CMD
-          value: "{{ $clusterConfigCommand }}"
-        {{- end }}
+          value: "{{ $securityResetCommand }}{{ $securityConfigureCommand }}{{ $clusterConfigCommand }}{{ $securityResetCommand }}{{ $securityConfigureCommand }}"
         - name: JAVA_OPTS
-          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
+          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} {{ if $securityResetCommand }} -Dhazelcast.mc.lock.skip=true {{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- with .Values.mancenter.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}        

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -85,6 +85,7 @@ spec:
           httpGet:
             path: {{ if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{ end }}/health
             port: 8081
+            scheme: HTTP
           initialDelaySeconds: {{ .Values.mancenter.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.mancenter.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.mancenter.livenessProbe.timeoutSeconds }}
@@ -150,9 +151,18 @@ spec:
             secretKeyRef:
               name: {{ .Values.mancenter.licenseKeySecretName }}
               key: key
-        {{- else if .Values.mancenter.licenseKey}}
+        {{- else if .Values.mancenter.licenseKey }}
         - name: MC_LICENSE_KEY
           value: {{ .Values.mancenter.licenseKey }}
+        {{- else if .Values.hazelcast.licenseKeySecretName }}
+        - name: MC_LICENSE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.hazelcast.licenseKeySecretName }}
+              key: key
+        {{- else if .Values.hazelcast.licenseKey}}
+        - name: MC_LICENSE_KEY
+          value: {{ .Values.hazelcast.licenseKey }}
         {{- end }}
         {{- $clusterConfigCommand := "" }}
         {{- if .Values.mancenter.clusterConfig.create }}
@@ -166,7 +176,7 @@ spec:
           value: "{{ $clusterConfigCommand }}"
         {{- end }}
         - name: JAVA_OPTS
-          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
+          value: "{{ if or .Values.mancenter.licenseKey .Values.mancenter.licenseKeySecretName .Values.hazelcast.licenseKey .Values.hazelcast.licenseKeySecretName }}-Dhazelcast.mc.license=$(MC_LICENSE_KEY){{ end }} {{ if or .Values.mancenter.readinessProbe.enabled .Values.mancenter.livenessProbe.enabled }}-Dhazelcast.mc.healthCheck.enable=true{{ end }} -DserviceName={{ template "hazelcast.serviceName" . }} -Dnamespace={{ .Release.Namespace }} -Dhazelcast.mc.tls.enabled={{ .Values.mancenter.ssl }} -Dmancenter.ssl={{ .Values.mancenter.ssl }} {{ .Values.mancenter.javaOpts }}"
         {{- with .Values.mancenter.env }}
           {{- toYaml . | nindent 8 }}
         {{- end }}        
@@ -188,36 +198,35 @@ spec:
       serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
       volumes:
-      - name: config
-        configMap:
-           {{- if .Values.mancenter.existingConfigMap }}
-           name: {{ .Values.mancenter.existingConfigMap }}
-           {{- else }}
-           name: {{ template "mancenter.fullname" . }}-configuration
-           {{- end }}
-      {{- if .Values.mancenter.secretsMountName }}
-      - name: mancenter-secrets
-        secret:
-          secretName: {{ .Values.mancenter.secretsMountName }}
-      {{- end }}
-      - name: mancenter-storage
-        {{- if and (eq .Values.mancenter.persistence.enabled true) .Values.mancenter.persistence.existingClaim }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.mancenter.persistence.existingClaim }}
-        {{- else if (eq .Values.mancenter.persistence.enabled false) }}
-        emptyDir: {}
+        - name: config
+          configMap:
+            {{- if .Values.mancenter.existingConfigMap }}
+            name: {{ .Values.mancenter.existingConfigMap }}
+            {{- else }}
+            name: {{ template "mancenter.fullname" . }}-configuration
+            {{- end }}
+        {{- if .Values.mancenter.secretsMountName }}
+        - name: mancenter-secrets
+          secret:
+            secretName: {{ .Values.mancenter.secretsMountName }}
         {{- end }}
-      {{- if .Values.mancenter.customVolume }}
-      - name: mancenter-custom
-{{ toYaml .Values.mancenter.customVolume | indent 8 }}
-      {{- end }}
-    {{ if and (eq .Values.mancenter.persistence.enabled true) (empty .Values.mancenter.persistence.existingClaim) }}
+        - name: mancenter-storage
+          {{- if and (eq .Values.mancenter.persistence.enabled true) .Values.mancenter.persistence.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.mancenter.persistence.existingClaim }}
+          {{- else if (eq .Values.mancenter.persistence.enabled false) }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.mancenter.customVolume }}
+        - name: mancenter-custom
+{{ toYaml .Values.mancenter.customVolume | indent 10 }}
+        {{- end }}
+      {{ if and (eq .Values.mancenter.persistence.enabled true) (empty .Values.mancenter.persistence.existingClaim) }}
   volumeClaimTemplates:
   - metadata:
       name: mancenter-storage
       labels:
         app.kubernetes.io/name: {{ template "mancenter.name" . }}
-        helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     spec:

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -67,6 +67,10 @@ spec:
       topologySpreadConstraints:
 {{ toYaml .Values.mancenter.topologySpreadConstraints | indent 8 }}
       {{- end }}
+      {{- if .Values.mancenter.initContainers }}
+      initContainers:
+{{ toYaml .Values.mancenter.initContainers | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ template "mancenter.fullname" . }}
         {{- if empty .Values.mancenter.image.tag }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- range $key, $val := .Values.annotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
-  {{- end }} 
+  {{- end }}
 spec:
   serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}
@@ -33,9 +33,9 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: hazelcast
-        {{- if .Values.podLabels }}
+      {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8 }}
-        {{- end }}
+      {{- end }}
       annotations:
         checksum/hazelcast-config: {{ toYaml .Values.hazelcast.yaml | sha256sum }}
         {{- range $key, $val := .Values.annotations }}
@@ -110,6 +110,7 @@ spec:
           httpGet:
             path: {{ .Values.livenessProbe.path }}
             port: {{ if .Values.livenessProbe.port }}{{ .Values.livenessProbe.port }}{{ else if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
+            scheme: {{ .Values.livenessProbe.scheme }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -121,6 +122,7 @@ spec:
           httpGet:
             path: {{ .Values.readinessProbe.path }}
             port: {{ if .Values.readinessProbe.port }}{{ .Values.readinessProbe.port }}{{ else if .Values.hostPort }}{{ .Values.hostPort }}{{ else }}5701{{ end }}
+            scheme: {{ .Values.readinessProbe.scheme }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
@@ -139,6 +141,16 @@ spec:
           mountPath: /data/external
         {{- end }}
         env:
+        {{- if .Values.hazelcast.licenseKeySecretName }}
+        - name: HZ_LICENSEKEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.hazelcast.licenseKeySecretName }}
+              key: key
+        {{- else if .Values.hazelcast.licenseKey}}
+        - name: HZ_LICENSEKEY
+          value: {{ .Values.hazelcast.licenseKey }}
+          {{- end }}
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -181,19 +193,24 @@ spec:
       serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
       volumes:
-      - name: hazelcast-storage
-        configMap:
-          {{- if .Values.hazelcast.existingConfigMap }}
-          name: {{ .Values.hazelcast.existingConfigMap }}
-          {{- else }}
-          name: {{ template "hazelcast.fullname" . }}-configuration
-          {{- end }}
-      {{- if .Values.customVolume }}
-      - name: hazelcast-custom
-{{ toYaml .Values.customVolume | indent 8 }}
-      {{- end }}
-      {{- if .Values.externalVolume }}
-      - name: hazelcast-external
-{{ toYaml .Values.externalVolume | indent 8 }}
+        - name: hazelcast-storage
+          configMap:
+            {{- if .Values.hazelcast.existingConfigMap }}
+            name: {{ .Values.hazelcast.existingConfigMap }}
+            {{- else }}
+            name: {{ template "hazelcast.fullname" . }}-configuration
+            {{- end }}
+        {{- if .Values.secretsMountName }}
+        - name: hazelcast-secrets
+          secret:
+            secretName: {{ .Values.secretsMountName }}
+        {{- end }}
+        {{- if .Values.customVolume }}
+        - name: hazelcast-custom
+{{ toYaml .Values.customVolume | indent 10 }}
+        {{- end }}
+        {{- if .Values.externalVolume }}
+        - name: hazelcast-external
+{{ toYaml .Values.externalVolume | indent 10 }}
       {{- end }}
 {{- end }}

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -121,8 +121,6 @@ livenessProbe:
   path: /hazelcast/health/node-state
   # port that will be used in liveness probe calls
   # port:
-  # HTTPS or HTTP scheme
-  scheme: HTTP
 
 # Hazelcast Readiness probe
 readinessProbe:
@@ -142,8 +140,6 @@ readinessProbe:
   path: /hazelcast/health/ready
   # port that will be used in readiness probe calls
   # port:
-  # HTTPS or HTTP scheme
-  scheme: HTTP
 
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -217,11 +213,6 @@ securityContext:
   # readOnlyRootFilesystem is a flag to enable readOnlyRootFilesystem for the Hazelcast security context
   readOnlyRootFilesystem: true
 
-# Hazelcast Jet Engine
-jet:
-  # enabled is a flag to enabled Jet engine
-  enabled: true
-
 # Allows to enable a Prometheus to scrape pods, implemented for Hazelcast version >= 3.12 (or 'latest')
 metrics:
   enabled: false
@@ -270,9 +261,6 @@ metrics:
   #        description: |
   #          Hazelcast instance {{ "{{ $labels.pod }}" }} is using {{ "{{ $value }}" }}% of its available memory.
 
-# secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
-# secretsMountName:
-
 # customVolume is the configuration for any volume mounted as '/data/custom/' and exposed to classpath (e.g. to mount a volume with custom JARs)
 # customVolume:
 
@@ -299,6 +287,11 @@ env: []
   #       key: db-username
   #       name: servicename-db-creds
 
+# Hazelcast Jet Engine
+jet:
+  # enabled is a flag to enabled Jet engine
+  enabled: true
+
 # Hazelcast Management Center application properties
 mancenter:
   # enabled is a flag to enable Management Center application
@@ -323,11 +316,6 @@ mancenter:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     # pullSecrets:
     # - myRegistryKeySecretName
-
-  # Dev mode is for the Hazelcast clusters running on your local for development
-  # or evaluation purposes and it provides quick access to the Management Center without requiring any security credentials
-  devMode:
-    enabled: false
 
   # ingress configuration for mancenter
   ingress:
@@ -358,8 +346,34 @@ mancenter:
   # licenseKeySecretName is the name of the secret where the Hazelcast Management Center License Key is stored (can be used instead of licenseKey)
   # licenseKeySecretName:
 
+  # Dev mode is for the Hazelcast clusters running on your local for development or evaluation purposes and it provides quick access to the Management Center without requiring any security credentials
+  # Deprected in favor of the `security` config block.
+  # This is mutually exclusive with adminCredentialsSecretName
+  devMode:
+    enabled: false
+
   # adminCredentialsSecretName is Kubernetes Secret Name for admin credentials. Secret has to contain `username` and `password` literals. please check Management Center documentation for password requirements
+  # If this is set it will conflict with devMode or security.activeDirectory.enabled == true
   # adminCredentialsSecretName:
+
+  security:
+    # The follow options are mutually exclusive
+    devMode:
+      enabled: false
+    activeDirectory:
+      enabled: false
+      url: ldap://localhost:10389
+      domain: example.com
+      userSearchFilter: "(&(objectClass=user)(userPrincipalName={0}))"
+      nestedGroupSearch: true
+      adminGroups: #[]
+        - HazelcastMCAdmin
+      userGroups: #[]
+        - HazelcastMCUser
+      readOnlyGroups: #[]
+        - HazelcastMCReadonlyUser
+      metricOnlyGroups: #[]
+        - HazelcastMCMetricsOnlyUser
 
   # existingConfigMap defines a ConfigMap which contains Hazelcast Client configuration file(s) that are used instead of hazelcast-client.yaml configuration below
   # existingConfigMap:
@@ -371,6 +385,10 @@ mancenter:
           enabled: true
           service-name: ${serviceName}
           namespace: ${namespace}
+  # Cluster config creation will create the connection to the Hazelcast cluster based on the yaml.hazelcast-client
+  clusterConfig:
+    # create is a flag used to enable cluster config creation
+    create: true
 
   # annotations is an array of metadata for Management Center Statefulset
   annotations: {}
@@ -482,10 +500,6 @@ mancenter:
     # failureThreshold is the minimum consecutive failures for the probe to be considered failed after having succeeded
     failureThreshold: 3
 
-  # Cluster config creation will create the connection to the Hazelcast cluster based on the yaml.hazelcast-client
-  clusterConfig:
-    # create is a flag used to enable cluster config creation
-    create: true
   # secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
   # secretsMountName:
 

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -296,6 +296,7 @@ jet:
 mancenter:
   # enabled is a flag to enable Management Center application
   enabled: true
+
   ## Hazelcast Management Center image version
   ## ref: https://hub.docker.com/r/hazelcast/management-center/tags/
   ##
@@ -316,6 +317,12 @@ mancenter:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     # pullSecrets:
     # - myRegistryKeySecretName
+
+  # Init containers for Management Center
+  initContainers: []
+  #  - name: init-myservice
+  #    image: busybox:1.28
+  #    command: ['sh', '-c', "sleep 2"]
 
   # ingress configuration for mancenter
   ingress:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -121,6 +121,8 @@ livenessProbe:
   path: /hazelcast/health/node-state
   # port that will be used in liveness probe calls
   # port:
+  # HTTPS or HTTP scheme
+  scheme: HTTP
 
 # Hazelcast Readiness probe
 readinessProbe:
@@ -140,6 +142,8 @@ readinessProbe:
   path: /hazelcast/health/ready
   # port that will be used in readiness probe calls
   # port:
+  # HTTPS or HTTP scheme
+  scheme: HTTP
 
 # Configure resource requests and limits
 # ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -213,6 +217,11 @@ securityContext:
   # readOnlyRootFilesystem is a flag to enable readOnlyRootFilesystem for the Hazelcast security context
   readOnlyRootFilesystem: true
 
+# Hazelcast Jet Engine
+jet:
+  # enabled is a flag to enabled Jet engine
+  enabled: true
+
 # Allows to enable a Prometheus to scrape pods, implemented for Hazelcast version >= 3.12 (or 'latest')
 metrics:
   enabled: false
@@ -261,6 +270,9 @@ metrics:
   #        description: |
   #          Hazelcast instance {{ "{{ $labels.pod }}" }} is using {{ "{{ $value }}" }}% of its available memory.
 
+# secretsMountName is the secret name that is mounted as '/data/secrets/' (e.g. with keystore/trustore files)
+# secretsMountName:
+
 # customVolume is the configuration for any volume mounted as '/data/custom/' and exposed to classpath (e.g. to mount a volume with custom JARs)
 # customVolume:
 
@@ -286,11 +298,6 @@ env: []
   #     secretKeyRef:
   #       key: db-username
   #       name: servicename-db-creds
-
-# Hazelcast Jet Engine
-jet:
-  # enabled is a flag to enabled Jet engine
-  enabled: true
 
 # Hazelcast Management Center application properties
 mancenter:


### PR DESCRIPTION
These charts are nearly functionally identical to each other. This change fixes the formatting between the two so files can be compared more easily to see differences between them. Additionally, settings exist in the values.yaml on the hazelcast chart that were not consumed by the templates, like the license key. This corrects for that. The only functional difference between the two now should be the support for hazelcast persistence.

This also further adds init containers for mancetner and the option to configure Active Directory auth in backwards compatible way.