### PR TITLE
[CN-993] Common label and annotation parameters for all deployed objects

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.10.5
+version: 5.10.6
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.10.6
+version: 5.10.7
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/config.yaml
+++ b/stable/hazelcast-enterprise/templates/config.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 data:
 {{- range $key, $val := .Values.hazelcast.configurationFiles }}
   {{ $key }}: |-

--- a/stable/hazelcast-enterprise/templates/mancenter-config.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-config.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 data:
   hazelcast-client.yaml: |-
 {{ toYaml .Values.mancenter.yaml | indent 4 }}

--- a/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
   {{- if or .Values.mancenter.ingress.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.mancenter.ingress.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.mancenter.ingress.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
@@ -8,10 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-{{- with .Values.mancenter.ingress.annotations }}
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if or .Values.mancenter.ingress.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- range $key, $val := (merge .Values.mancenter.ingress.annotations .Values.commonAnnotations) }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.mancenter.ingress.className }}
 {{- if .Values.mancenter.ingress.tls }}

--- a/stable/hazelcast-enterprise/templates/mancenter-service.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-service.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.mancenter.service.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.mancenter.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast-enterprise/templates/mancenter-service.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-service.yaml
@@ -12,9 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.mancenter.service.labels }}
+    {{- range $key, $value := (merge .Values.mancenter.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.mancenter.service.type }}
   {{- if .Values.mancenter.service.clusterIP }}

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.mancenter.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.mancenter.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -33,12 +33,16 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: mancenter
-        {{- if .Values.mancenter.podLabels }}
-{{ toYaml .Values.mancenter.podLabels | indent 8 }}
+        {{- if or .Values.mancenter.podLabels .Values.commonLabels }}
+        {{- range $key, $val := (merge nil .Values.mancenter.podLabels .Values.commonLabels) }}
+        {{ $key }}: {{ $val | quote }}
         {{- end }}
-      {{- if .Values.mancenter.annotations }}
+        {{- end }}
+      {{- if or .Values.mancenter.annotations .Values.commonAnnotations }}
       annotations:
-{{ toYaml .Values.mancenter.annotations | indent 8 }}
+        {{- range $key, $val := (merge nil .Values.mancenter.annotations .Values.commonAnnotations) }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if .Values.mancenter.image.pullSecrets }}
@@ -235,6 +239,15 @@ spec:
         app.kubernetes.io/name: {{ template "mancenter.name" . }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        {{- range $key, $value := .Values.commonLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- if .Values.commonAnnotations }}
+      annotations:
+        {{- range $key, $val := .Values.commonAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
     spec:
       accessModes:
       {{- range .Values.mancenter.persistence.accessModes }}

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -8,9 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.mancenter.labels }}
+    {{- range $key, $value := (merge .Values.mancenter.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   serviceName: {{ template "mancenter.fullname" . }}
   replicas: 1

--- a/stable/hazelcast-enterprise/templates/metrics-service.yaml
+++ b/stable/hazelcast-enterprise/templates/metrics-service.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- end }}
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.metrics.service.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.metrics.service.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast-enterprise/templates/metrics-service.yaml
+++ b/stable/hazelcast-enterprise/templates/metrics-service.yaml
@@ -10,8 +10,15 @@ metadata:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     app.kubernetes.io/component: metrics
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
   annotations:
-{{ toYaml .Values.metrics.service.annotations | indent 4 }}
+    {{- range $key, $val := (merge .Values.metrics.service.annotations .Values.commonAnnotations) }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}
   {{- if (and (eq .Values.metrics.service.type "LoadBalancer") (.Values.metrics.service.loadBalancerIP)) }}

--- a/stable/hazelcast-enterprise/templates/poddisruptionbudget.yaml
+++ b/stable/hazelcast-enterprise/templates/poddisruptionbudget.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
   selector:

--- a/stable/hazelcast-enterprise/templates/prometheusrule.yaml
+++ b/stable/hazelcast-enterprise/templates/prometheusrule.yaml
@@ -9,9 +9,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := .Values.metrics.prometheusRule.labels }}
+    {{- range $key, $val := (merge .Values.metrics.prometheusRule.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   groups:
     - name: {{ template "hazelcast.name" . }}

--- a/stable/hazelcast-enterprise/templates/prometheusrule.yaml
+++ b/stable/hazelcast-enterprise/templates/prometheusrule.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := (merge .Values.metrics.prometheusRule.labels .Values.commonLabels) }}
+    {{- range $key, $val := (merge nil .Values.metrics.prometheusRule.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast-enterprise/templates/role.yaml
+++ b/stable/hazelcast-enterprise/templates/role.yaml
@@ -12,6 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/stable/hazelcast-enterprise/templates/rolebinding.yaml
+++ b/stable/hazelcast-enterprise/templates/rolebinding.yaml
@@ -12,6 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- if .Values.rbac.useClusterRole }}

--- a/stable/hazelcast-enterprise/templates/service-external.yaml
+++ b/stable/hazelcast-enterprise/templates/service-external.yaml
@@ -12,13 +12,15 @@ metadata:
     app.kubernetes.io/instance: "{{ $.Release.Name }}"
     app.kubernetes.io/managed-by: "{{ $.Release.Service }}"
     pod: {{ $targetPod }}
-    {{- range $key, $value := $.Values.externalAccess.service.labels }}
+    {{- range $key, $value := (merge .Values.externalAccess.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-{{- with $.Values.externalAccess.service.annotations }}
+  {{- if or .Values.externalAccess.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- range $key, $val := (merge .Values.externalAccess.service.annotations .Values.commonAnnotations) }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ $.Values.externalAccess.service.type }}
   {{- if $.Values.externalAccess.service.loadBalancerIPs }}

--- a/stable/hazelcast-enterprise/templates/service-external.yaml
+++ b/stable/hazelcast-enterprise/templates/service-external.yaml
@@ -12,12 +12,12 @@ metadata:
     app.kubernetes.io/instance: "{{ $.Release.Name }}"
     app.kubernetes.io/managed-by: "{{ $.Release.Service }}"
     pod: {{ $targetPod }}
-    {{- range $key, $value := (merge .Values.externalAccess.service.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.externalAccess.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if or .Values.externalAccess.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.externalAccess.service.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.externalAccess.service.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast-enterprise/templates/service.yaml
+++ b/stable/hazelcast-enterprise/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.service.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast-enterprise/templates/service.yaml
+++ b/stable/hazelcast-enterprise/templates/service.yaml
@@ -12,9 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.service.labels }}
+    {{- range $key, $value := (merge .Values.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP)) }}

--- a/stable/hazelcast-enterprise/templates/serviceaccount.yaml
+++ b/stable/hazelcast-enterprise/templates/serviceaccount.yaml
@@ -8,4 +8,13 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/stable/hazelcast-enterprise/templates/servicemonitor.yaml
+++ b/stable/hazelcast-enterprise/templates/servicemonitor.yaml
@@ -9,9 +9,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := .Values.metrics.serviceMonitor.labels }}
+    {{- range $key, $val := (merge .Values.metrics.serviceMonitor.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   endpoints:
     - port: {{ .Values.metrics.service.portName }}

--- a/stable/hazelcast-enterprise/templates/servicemonitor.yaml
+++ b/stable/hazelcast-enterprise/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := (merge .Values.metrics.serviceMonitor.labels .Values.commonLabels) }}
+    {{- range $key, $val := (merge nil .Values.metrics.serviceMonitor.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -33,12 +33,14 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: hazelcast
-      {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
-      {{- end }}
+        {{- if or .Values.podLabels .Values.commonLabels }}
+        {{- range $key, $val := (merge nil .Values.podLabels .Values.commonLabels) }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+        {{- end }}
       annotations:
         checksum/hazelcast-config: {{ toYaml .Values.hazelcast.yaml | sha256sum }}
-        {{- range $key, $val := .Values.annotations }}
+        {{- range $key, $val := (merge nil .Values.annotations .Values.commonAnnotations) }}
         {{ $key }}: {{ $val | quote }}
         {{- end }}
     spec:
@@ -241,6 +243,15 @@ spec:
         app.kubernetes.io/name: {{ template "hazelcast.name" . }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        {{- range $key, $value := .Values.commonLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- if .Values.commonAnnotations }}
+      annotations:
+        {{- range $key, $val := .Values.commonAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
     spec:
       accessModes:
       {{- range .Values.persistence.accessModes }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -8,12 +8,12 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if or .Values.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -8,12 +8,12 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.labels }}
+    {{- range $key, $value := (merge .Values.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-  {{- if .Values.annotations }}
+  {{- if or .Values.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := .Values.annotations }}
+    {{- range $key, $val := (merge .Values.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -25,6 +25,12 @@ cluster:
   # memberCount is the number Hazelcast members
   memberCount: 3
 
+# Labels to add to all deployed objects
+commonLabels: {}
+
+# Annotations to add to all deployed objects
+commonAnnotations: {}
+
 # Hazelcast properties
 hazelcast:
   # enabled is a flag to enable Hazelcast application

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.7
+version: 5.8.8
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.6
+version: 5.8.7
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/config.yaml
+++ b/stable/hazelcast/templates/config.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 data:
 {{- range $key, $val := .Values.hazelcast.configurationFiles }}
   {{ $key }}: |-

--- a/stable/hazelcast/templates/mancenter-config.yaml
+++ b/stable/hazelcast/templates/mancenter-config.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 data:
   hazelcast-client.yaml: |-
 {{ toYaml .Values.mancenter.yaml | indent 4 }}

--- a/stable/hazelcast/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast/templates/mancenter-ingress.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
   {{- if or .Values.mancenter.ingress.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.mancenter.ingress.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.mancenter.ingress.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast/templates/mancenter-ingress.yaml
@@ -8,10 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-{{- with .Values.mancenter.ingress.annotations }}
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if or .Values.mancenter.ingress.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- range $key, $val := (merge .Values.mancenter.ingress.annotations .Values.commonAnnotations) }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ .Values.mancenter.ingress.className }}
 {{- if .Values.mancenter.ingress.tls }}

--- a/stable/hazelcast/templates/mancenter-service.yaml
+++ b/stable/hazelcast/templates/mancenter-service.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.mancenter.service.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.mancenter.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast/templates/mancenter-service.yaml
+++ b/stable/hazelcast/templates/mancenter-service.yaml
@@ -12,9 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.mancenter.service.labels }}
+    {{- range $key, $value := (merge .Values.mancenter.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.mancenter.service.type }}
   {{- if .Values.mancenter.service.clusterIP }}

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -33,12 +33,16 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: mancenter
-        {{- if .Values.mancenter.podLabels }}
-{{ toYaml .Values.mancenter.podLabels | indent 8 }}
+        {{- if or .Values.mancenter.podLabels .Values.commonLabels }}
+        {{- range $key, $val := (merge nil .Values.mancenter.podLabels .Values.commonLabels) }}
+        {{ $key }}: {{ $val | quote }}
         {{- end }}
-      {{- if .Values.mancenter.annotations }}
+        {{- end }}
+      {{- if or .Values.mancenter.annotations .Values.commonAnnotations }}
       annotations:
-{{ toYaml .Values.mancenter.annotations | indent 8 }}
+        {{- range $key, $val := (merge nil .Values.mancenter.annotations .Values.commonAnnotations) }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
       {{- end }}
     spec:
       {{- if .Values.mancenter.image.pullSecrets }}
@@ -226,6 +230,15 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+        {{- range $key, $value := .Values.commonLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- if .Values.commonAnnotations }}
+      annotations:
+        {{- range $key, $val := .Values.commonAnnotations }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
     spec:
       accessModes:
       {{- range .Values.mancenter.persistence.accessModes }}

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.mancenter.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.mancenter.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -8,9 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.mancenter.labels }}
+    {{- range $key, $value := (merge .Values.mancenter.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   serviceName: {{ template "mancenter.fullname" . }}
   replicas: 1

--- a/stable/hazelcast/templates/metrics-service.yaml
+++ b/stable/hazelcast/templates/metrics-service.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- end }}
   {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.metrics.service.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.metrics.service.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast/templates/metrics-service.yaml
+++ b/stable/hazelcast/templates/metrics-service.yaml
@@ -10,8 +10,15 @@ metadata:
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
     app.kubernetes.io/component: metrics
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if or .Values.metrics.service.annotations .Values.commonAnnotations }}
   annotations:
-{{ toYaml .Values.metrics.service.annotations | indent 4 }}
+    {{- range $key, $val := (merge .Values.metrics.service.annotations .Values.commonAnnotations) }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.metrics.service.type }}
   {{- if (and (eq .Values.metrics.service.type "LoadBalancer") (.Values.metrics.service.loadBalancerIP)) }}

--- a/stable/hazelcast/templates/poddisruptionbudget.yaml
+++ b/stable/hazelcast/templates/poddisruptionbudget.yaml
@@ -8,6 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
   selector:

--- a/stable/hazelcast/templates/prometheusrule.yaml
+++ b/stable/hazelcast/templates/prometheusrule.yaml
@@ -9,9 +9,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := .Values.metrics.prometheusRule.labels }}
+    {{- range $key, $val := (merge .Values.metrics.prometheusRule.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   groups:
     - name: {{ template "hazelcast.name" . }}

--- a/stable/hazelcast/templates/prometheusrule.yaml
+++ b/stable/hazelcast/templates/prometheusrule.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := (merge .Values.metrics.prometheusRule.labels .Values.commonLabels) }}
+    {{- range $key, $val := (merge nil .Values.metrics.prometheusRule.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast/templates/role.yaml
+++ b/stable/hazelcast/templates/role.yaml
@@ -12,6 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""

--- a/stable/hazelcast/templates/rolebinding.yaml
+++ b/stable/hazelcast/templates/rolebinding.yaml
@@ -12,6 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- if .Values.rbac.useClusterRole }}

--- a/stable/hazelcast/templates/service-external.yaml
+++ b/stable/hazelcast/templates/service-external.yaml
@@ -12,13 +12,15 @@ metadata:
     app.kubernetes.io/instance: "{{ $.Release.Name }}"
     app.kubernetes.io/managed-by: "{{ $.Release.Service }}"
     pod: {{ $targetPod }}
-    {{- range $key, $value := $.Values.externalAccess.service.labels }}
+    {{- range $key, $value := (merge .Values.externalAccess.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-{{- with $.Values.externalAccess.service.annotations }}
+  {{- if or .Values.externalAccess.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- range $key, $val := (merge .Values.externalAccess.service.annotations .Values.commonAnnotations) }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ $.Values.externalAccess.service.type }}
   {{- if $.Values.externalAccess.service.loadBalancerIPs }}

--- a/stable/hazelcast/templates/service-external.yaml
+++ b/stable/hazelcast/templates/service-external.yaml
@@ -12,12 +12,12 @@ metadata:
     app.kubernetes.io/instance: "{{ $.Release.Name }}"
     app.kubernetes.io/managed-by: "{{ $.Release.Service }}"
     pod: {{ $targetPod }}
-    {{- range $key, $value := (merge .Values.externalAccess.service.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.externalAccess.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if or .Values.externalAccess.service.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.externalAccess.service.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.externalAccess.service.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast/templates/service.yaml
+++ b/stable/hazelcast/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.service.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast/templates/service.yaml
+++ b/stable/hazelcast/templates/service.yaml
@@ -12,9 +12,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.service.labels }}
+    {{- range $key, $value := (merge .Values.service.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP)) }}

--- a/stable/hazelcast/templates/serviceaccount.yaml
+++ b/stable/hazelcast/templates/serviceaccount.yaml
@@ -8,4 +8,13 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+    {{- range $key, $value := .Values.commonLabels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/stable/hazelcast/templates/servicemonitor.yaml
+++ b/stable/hazelcast/templates/servicemonitor.yaml
@@ -9,9 +9,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := .Values.metrics.serviceMonitor.labels }}
+    {{- range $key, $val := (merge .Values.metrics.serviceMonitor.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- range $key, $val := .Values.commonAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  {{- end }}
 spec:
   endpoints:
     - port: {{ .Values.metrics.service.portName }}

--- a/stable/hazelcast/templates/servicemonitor.yaml
+++ b/stable/hazelcast/templates/servicemonitor.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $val := (merge .Values.metrics.serviceMonitor.labels .Values.commonLabels) }}
+    {{- range $key, $val := (merge nil .Values.metrics.serviceMonitor.labels .Values.commonLabels) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- if .Values.commonAnnotations }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -8,12 +8,12 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := (merge .Values.labels .Values.commonLabels) }}
+    {{- range $key, $value := (merge nil .Values.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
   {{- if or .Values.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := (merge .Values.annotations .Values.commonAnnotations) }}
+    {{- range $key, $val := (merge nil .Values.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
   {{- end }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -8,15 +8,15 @@ metadata:
     helm.sh/chart: {{ template "hazelcast.chart" . }}
     app.kubernetes.io/instance: "{{ .Release.Name }}"
     app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-    {{- range $key, $value := .Values.labels }}
+    {{- range $key, $value := (merge .Values.labels .Values.commonLabels) }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
-  {{- if .Values.annotations }}
+  {{- if or .Values.annotations .Values.commonAnnotations }}
   annotations:
-    {{- range $key, $val := .Values.annotations }}
+    {{- range $key, $val := (merge .Values.annotations .Values.commonAnnotations) }}
     {{ $key }}: {{ $val | quote }}
     {{- end }}
-  {{- end }} 
+  {{- end }}
 spec:
   serviceName: {{ template "hazelcast.fullname" . }}
   replicas: {{ .Values.cluster.memberCount }}

--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -33,12 +33,14 @@ spec:
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
         role: hazelcast
-        {{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
+        {{- if or .Values.podLabels .Values.commonLabels }}
+        {{- range $key, $val := (merge nil .Values.podLabels .Values.commonLabels) }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
         {{- end }}
       annotations:
         checksum/hazelcast-config: {{ toYaml .Values.hazelcast.yaml | sha256sum }}
-        {{- range $key, $val := .Values.annotations }}
+        {{- range $key, $val := (merge nil .Values.annotations .Values.commonAnnotations) }}
         {{ $key }}: {{ $val | quote }}
         {{- end }}
     spec:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -25,6 +25,12 @@ cluster:
   # memberCount is the number Hazelcast members
   memberCount: 3
 
+# Labels to add to all deployed objects
+commonLabels: {}
+
+# Annotations to add to all deployed objects
+commonAnnotations: {}
+
 # Hazelcast properties
 hazelcast:
   # enabled is a flag to enable Hazelcast application


### PR DESCRIPTION
provides a way to add common labels and annotations to all objects deployed by the chart

```yaml
# Labels to add to all deployed objects
commonLabels: {}

# Annotations to add to all deployed objects
commonAnnotations: {}
```

## Implementation Notes

To merge two maps, we are using `merge` function. eg:

```
merge nil .Values.mancenter.ingress.annotations .Values.commonAnnotations
```

The reason why we are passing `nil` to the first parameter of `merge` function is to keep the maps immutable. 

```
$newdict := merge $dest $source1 $source2
```

The first parameter of the `merge` function is destination. The new merging entries are put into the destination map.

https://helm.sh/docs/chart_template_guide/function_list/#merge-mustmerge

We are passing `nil` as a destination map in order to not modify any of our existing map. In this way, the maps generated from the values.yaml and user args are not modified during the render process of templates.

