### PR TITLE
[CN-1023] Add flag to disable chart tests

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.10.5
+version: 5.10.6
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-hazelcast.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hazelcast.enabled }}
+{{- if and .Values.hazelcast.enabled .Values.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast-enterprise/templates/tests/test-management-center.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mancenter.enabled }}
+{{- if and .Values.mancenter.enabled .Values.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -572,6 +572,8 @@ externalAccess:
     # Annotations for the services that will be created.
     annotations: {}
 test:
+  # enabled is a flag to enable Hazelcast chart test
+  enabled: true
   ## Hazelcast chart test hook image version
   image:
     # repository is the chart test hook image name

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.6
+version: 5.8.7
 appVersion: "5.3.2"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/tests/test-hazelcast.yaml
+++ b/stable/hazelcast/templates/tests/test-hazelcast.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hazelcast.enabled }}
+{{- if and .Values.hazelcast.enabled .Values.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast/templates/tests/test-management-center.yaml
+++ b/stable/hazelcast/templates/tests/test-management-center.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mancenter.enabled }}
+{{- if and .Values.mancenter.enabled .Values.test.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -534,6 +534,8 @@ externalAccess:
     annotations: {}
 
 test:
+  # enabled is a flag to enable Hazelcast chart test
+  enabled: true
   ## Hazelcast chart test hook image version
   image:
     # repository is the chart test hook image name


### PR DESCRIPTION
Ability to enable/disable Hazelcast chart test pod. This is needed to control the pod in more complicated multi chart deployments.