### PR TITLE
Bump chart-testing-action to 2.6.0

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -84,7 +84,7 @@ jobs:
           python-version: 3.7
                     
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.0
 
       - name: Add values.yaml for testing
         run: |


### PR DESCRIPTION
New version 2.6.0 fix the issue when cosign v2.0.0 can't be downloaded in PR builder workflow 
`INFO: Downloading bootstrap version 'v2.0.0' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v2.0.0/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v2.0.0'
Error: Process completed with exit code 1.`