### PR TITLE
Ability to change jvm.options

### DIFF
--- a/stable/hazelcast/templates/statefulset.yaml
+++ b/stable/hazelcast/templates/statefulset.yaml
@@ -130,6 +130,14 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         {{- end }}
         volumeMounts:
+        {{- range $key, $val := .Values.hazelcast.configurationFiles }}
+        - name: config
+          mountPath: /opt/hazelcast/config/{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
+        - name: config
+          mountPath: /opt/hazelcast/config/hazelcast.yaml
+          subPath: hazelcast.yaml
         - name: hazelcast-storage
           mountPath: /data/hazelcast
         {{- if .Values.customVolume }}
@@ -157,7 +165,7 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
         - name: JAVA_OPTS
-          value: "-Dhazelcast.config=/data/hazelcast/hazelcast.yaml -DserviceName={{ template "hazelcast.serviceNameConfig" . }} -Dnamespace={{ .Release.Namespace }} -Dhz.jet.enabled={{ .Values.jet.enabled }} {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
+          value: "-Dhazelcast.config=/opt/hazelcast/config/hazelcast.yaml -DserviceName={{ template "hazelcast.serviceNameConfig" . }} -Dnamespace={{ .Release.Namespace }} -Dhz.jet.enabled={{ .Values.jet.enabled }} {{ if .Values.gracefulShutdown.enabled }}-Dhazelcast.shutdownhook.policy=GRACEFUL -Dhazelcast.shutdownhook.enabled=true -Dhazelcast.graceful.shutdown.max.wait={{ .Values.gracefulShutdown.maxWaitSeconds }} {{ end }} {{ if .Values.metrics.enabled }}-Dhazelcast.jmx=true{{ end }} {{ .Values.hazelcast.javaOpts }}"
         {{- if .Values.hazelcast.loggingLevel }}
         - name: LOGGING_LEVEL
           value: {{ .Values.hazelcast.loggingLevel }}
@@ -183,13 +191,15 @@ spec:
       serviceAccountName: {{ template "hazelcast.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountToken }}
       volumes:
-      - name: hazelcast-storage
+      - name: config
         configMap:
           {{- if .Values.hazelcast.existingConfigMap }}
           name: {{ .Values.hazelcast.existingConfigMap }}
           {{- else }}
           name: {{ template "hazelcast.fullname" . }}-configuration
           {{- end }}
+      - name: hazelcast-storage
+        emptyDir: {}
       {{- if .Values.customVolume }}
       - name: hazelcast-custom
 {{ toYaml .Values.customVolume | indent 8 }}


### PR DESCRIPTION
- Configuration config map was improperly mapped to `hazelcast-storage` volume. This is fixed now -  `config` volume is used instead.
- `/data/hazelcast/hazelcast.yaml` configuration file is now properly mapped to  `/opt/hazelcast/config/hazelcast.yaml`
- All files under `Values.hazelcast.configurationFiles` are mapped to `/opt/hazelcast/config/` dir in hazecast container in case they exist.
i.e `.Values.hazelcast.configurationFiles.jmvOptions` is mapped to `/opt/hazelcast/config/jvm.options` in container

The main driver for fixing this was the inability to change JVM options 