### PR TITLE
[CN-1104]: remove common labels and annotations from volumeClaimTemplates

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.10.12
+version: 5.10.13
 appVersion: "5.3.6"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -233,13 +233,6 @@ spec:
         app.kubernetes.io/name: {{ template "mancenter.name" . }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-        {{- range $key, $value := .Values.commonLabels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-      {{- with .Values.commonAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
     spec:
       accessModes:
       {{- range .Values.mancenter.persistence.accessModes }}

--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -239,13 +239,6 @@ spec:
         app.kubernetes.io/name: {{ template "hazelcast.name" . }}
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-        {{- range $key, $value := .Values.commonLabels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-      {{- with .Values.commonAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
     spec:
       accessModes:
       {{- range .Values.persistence.accessModes }}

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.8.13
+version: 5.8.14
 appVersion: "5.3.6"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -224,13 +224,6 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}"
         app.kubernetes.io/instance: "{{ .Release.Name }}"
         app.kubernetes.io/managed-by: "{{ .Release.Service }}"
-        {{- range $key, $value := .Values.commonLabels }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-      {{- with .Values.commonAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
     spec:
       accessModes:
       {{- range .Values.mancenter.persistence.accessModes }}


### PR DESCRIPTION
When using `helm upgrade`, it is forbidden to update statefulsets' spec for fields other than `replicas`, `ordinals`, `template`, `updateStrategy`, `persistentVolumeClaimRetentionPolicy` and `minReadySeconds`. So, `volumeClaimTemplates` is not an updatable field during update. It should stay the same, we also created a task for it: CN-1105.