### PR TITLE
Add option to use custom ports for mancenter #409

### DIFF
--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -82,8 +82,12 @@ spec:
         resources:
 {{ toYaml .Values.mancenter.resources | indent 10 }}
         ports:
+        {{- if .Values.customPorts }}
+{{ toYaml .Values.customPorts | indent 8 }}
+        {{- else }}
         - name: mancenter
           containerPort: {{ if .Values.mancenter.ssl }}8443{{ else }}8080{{ end }}
+        {{- end }}
         {{- if .Values.mancenter.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -322,6 +322,8 @@ mancenter:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
     # pullSecrets:
     # - myRegistryKeySecretName
+  # customPorts is the whole ports section to customize how Hazelcast management center container ports are defined
+  # customPorts:
 
   # Dev mode is for the Hazelcast clusters running on your local for development
   # or evaluation purposes and it provides quick access to the Management Center without requiring any security credentials


### PR DESCRIPTION
Addresses #409 by allowing custom ports in the mancenter helm chart to enable clustered jmx.