### PR TITLE
Fix hazelcast-enterprise Anti-Affinity Example 

### DIFF
--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -85,7 +85,7 @@ affinity:
 #        - key: app.kubernetes.io/name
 #          operator: In
 #          values:
-#          - hazelcast
+#          - hazelcast-enterprise
 #        - key: role
 #          operator: In
 #          values:


### PR DESCRIPTION
In `values.yaml` the example for `podAntiAffinity` uses incorrect predicate match on key `app.kubernetes.io/name`. 