### PR TITLE
Added new Kubernetes StatefulSet PVC Auto-Deletion

### DIFF
--- a/stable/hazelcast-enterprise/templates/statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/statefulset.yaml
@@ -256,3 +256,12 @@ spec:
       {{- end }}
   {{- end }}
 {{- end }}
+{{- if .Values.persistence.volumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- if .Values.persistence.volumeClaimRetentionPolicy.whenDeleted }}
+    whenDeleted: {{ .Values.persistence.volumeClaimRetentionPolicy.whenDeleted }}
+    {{- end }}
+    {{- if .Values.persistence.volumeClaimRetentionPolicy.whenScaled }}
+    whenScaled: {{ .Values.persistence.volumeClaimRetentionPolicy.whenScaled }}
+    {{- end }}
+{{- end }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -252,6 +252,18 @@ persistence:
   # hostPath is the path of the node machine directory that is used for persistent storage
   # if defined, it's used instead of Persistent Volume Claim
   # hostPath:
+  # volumeClaimRetentionPolicy controls if and how PVCs are deleted during the lifecycle of a StatefulSet
+  # There are two retention policies to be set:
+  # whenDeleted - configures the volume retention behavior that applies when the StatefulSet is deleted
+  # and
+  # whenScaled - configures the volume retention behavior that applies when the replica count of the StatefulSet
+  # is reduced; for example, when scaling down the set.
+  #
+  # Values can be either Retain which is the default or Delete
+  #
+  # volumeClaimRetentionPolicy:
+  #   whenDeleted: Retain
+  #   whenScaled: Retain
 
 # Hazelcast Jet Engine
 jet:


### PR DESCRIPTION
Support for the new Auto-Deletion features for PVCs related to statefulsets.

https://kubernetes.io/blog/2023/05/04/kubernetes-1-27-statefulset-pvc-auto-deletion-beta/

This makes it easier to remove the persistence if an update is done so only the pvc can be deleted and the policy takes care if PVC should be deleted or not.