### PR TITLE
Change mancenter ingress to use contextPath

### DIFF
--- a/stable/hazelcast-enterprise/Chart.yaml
+++ b/stable/hazelcast-enterprise/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast-enterprise
-version: 5.14.0
+version: 5.14.1
 appVersion: "5.6.0"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-ingress.yaml
@@ -34,7 +34,7 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          - path: "/"
+          - path: {{ $.Values.mancenter.contextPath | quote }}
             pathType: Prefix
             backend:
                 service:
@@ -45,7 +45,7 @@ spec:
   {{- else }}
     - http:
         paths:
-          - path: "/"
+          - path: {{ .Values.mancenter.contextPath | quote }}
             pathType: Prefix
             backend:
                 service:

--- a/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast-enterprise/templates/mancenter-statefulset.yaml
@@ -87,7 +87,7 @@ spec:
         {{- if .Values.mancenter.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{ end }}/health
+            path: {{ if and .Values.mancenter.contextPath (ne .Values.mancenter.contextPath "/") }}{{ .Values.mancenter.contextPath }}{{ end }}/health
             port: 8081
             scheme: HTTP
           initialDelaySeconds: {{ .Values.mancenter.livenessProbe.initialDelaySeconds }}
@@ -141,7 +141,7 @@ spec:
               name: {{ .Values.mancenter.adminCredentialsSecretName }}
               key: password
         {{- end }}
-        {{- if .Values.mancenter.contextPath }}
+        {{- if and .Values.mancenter.contextPath (ne .Values.mancenter.contextPath "/") }}
         - name: MC_CONTEXT_PATH
           value: {{ .Values.mancenter.contextPath }}
         {{- end }}

--- a/stable/hazelcast-enterprise/values.yaml
+++ b/stable/hazelcast-enterprise/values.yaml
@@ -387,7 +387,7 @@ mancenter:
 
   # contextPath is the value for the MC_CONTEXT_PATH environment variable, thus overriding the default context path for Hazelcast Management Center
   # ref: https://hub.docker.com/r/hazelcast/management-center/
-  contextPath:
+  contextPath: "/"
 
   # licenseKey is the license key for Hazelcast Management Center
   # if not provided, it can be filled in the Management Center web interface

--- a/stable/hazelcast/Chart.yaml
+++ b/stable/hazelcast/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: hazelcast
-version: 5.10.2
+version: 5.10.3
 appVersion: "5.5.0"
 kubeVersion: ">=1.19.0-0"
 description: Hazelcast is a streaming and memory-first application platform for fast, stateful, data-intensive workloads on-premises, at the edge or as a fully managed cloud service.

--- a/stable/hazelcast/templates/mancenter-ingress.yaml
+++ b/stable/hazelcast/templates/mancenter-ingress.yaml
@@ -34,7 +34,7 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          - path: "/"
+          - path: {{ $.Values.mancenter.contextPath | quote }}
             pathType: Prefix
             backend:
                 service:
@@ -45,7 +45,7 @@ spec:
   {{- else }}
     - http:
         paths:
-          - path: "/"
+          - path: {{ .Values.mancenter.contextPath | quote }}
             pathType: Prefix
             backend:
                 service:

--- a/stable/hazelcast/templates/mancenter-statefulset.yaml
+++ b/stable/hazelcast/templates/mancenter-statefulset.yaml
@@ -87,7 +87,7 @@ spec:
         {{- if .Values.mancenter.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: {{ if .Values.mancenter.contextPath }}{{ .Values.mancenter.contextPath }}{{ end }}/health
+            path: {{ if and .Values.mancenter.contextPath (ne .Values.mancenter.contextPath "/") }}{{ .Values.mancenter.contextPath }}{{ end }}/health
             port: 8081
           initialDelaySeconds: {{ .Values.mancenter.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.mancenter.livenessProbe.periodSeconds }}
@@ -140,7 +140,7 @@ spec:
               name: {{ .Values.mancenter.adminCredentialsSecretName }}
               key: password
         {{- end }}
-        {{- if .Values.mancenter.contextPath }}
+        {{- if and .Values.mancenter.contextPath (ne .Values.mancenter.contextPath "/") }}
         - name: MC_CONTEXT_PATH
           value: {{ .Values.mancenter.contextPath }}
         {{- end }}

--- a/stable/hazelcast/values.yaml
+++ b/stable/hazelcast/values.yaml
@@ -349,7 +349,7 @@ mancenter:
 
   # contextPath is the value for the MC_CONTEXT_PATH environment variable, thus overriding the default context path for Hazelcast Management Center
   # ref: https://hub.docker.com/r/hazelcast/management-center/
-  contextPath:
+  contextPath: "/"
 
   # licenseKey is the license key for Hazelcast Management Center
   # if not provided, it can be filled in the Management Center web interface


### PR DESCRIPTION
Hello,

Maybe I missed something, but when you share your DNS between your application and your mancenter, the hardcoded "/" in the mancenter ingress make it impossible to be used and the contextPath is not fully used.
This PR changes this to use the contextPath in the Ingress configuration so you can expose your mancenter under a path of your common DNS.

### Version Updates:
* Updated `hazelcast-enterprise` chart version from `5.13.1` to `5.13.2` in `stable/hazelcast-enterprise/Chart.yaml`.
* Updated `hazelcast` chart version from `5.10.2` to `5.10.3` in `stable/hazelcast/Chart.yaml`.

### Management Center Context Path Handling:
* Changed the default `contextPath` value to `"/"` in `values.yaml` for both `hazelcast-enterprise` [[1]](diffhunk://#diff-563c65fe39c2bc72f123b3f1bc01272b3f6c19a75402d2ffb96619ee3ab7a161L390-R390) and `hazelcast` [[2]](diffhunk://#diff-bf15f07f5a629cfa47b24e8d88d947372138ca1e0a93c2d1638e2f9f55e9e005L352-R352).
* Updated `mancenter-ingress.yaml` to use the `contextPath` value dynamically instead of hardcoding `"/"`. [[1]](diffhunk://#diff-56ac056c2ac9861ee84019349d06c38c20e673aaea1bf8e7dfc195c96dd39d75L37-R37) [[2]](diffhunk://#diff-56ac056c2ac9861ee84019349d06c38c20e673aaea1bf8e7dfc195c96dd39d75L48-R48) for both `hazelcast-enterprise` and `hazelcast`)
* Modified `mancenter-statefulset.yaml` to set the `MC_CONTEXT_PATH` environment variable only if `contextPath` is defined and not equal to `"/"`. [[1]](diffhunk://#diff-3042df3029c91fc76afe275b2c35ddf5425e1bae2d3a49d4468bcfb97ec0de71L144-R144) for `hazelcast-enterprise`, [[2]](diffhunk://#diff-da1a29a6af36e384bca1310df167fb4e5aa55fbf94595cee3f20a22e079b7b89L143-R143) for `hazelcast`)